### PR TITLE
Fix web3 query skill docs

### DIFF
--- a/skills/binance-web3/query-address-info/SKILL.md
+++ b/skills/binance-web3/query-address-info/SKILL.md
@@ -35,7 +35,7 @@ https://web3.binance.com/bapi/defi/v3/public/wallet-direct/buw/wallet/address/pn
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | address | string | Yes | Wallet address, e.g., `0x0000000000000000000000000000000000000001` |
-| chainId | string | Yes | Chain ID, e.g., `56` (BSC), `1` (ETH), `8453` (Base) |
+| chainId | string | Yes | Chain ID, e.g., `56` (BSC), `8453` (Base) |
 | offset | number | No | Pagination offset, default 0 |
 
 **Request Headers**:
@@ -101,7 +101,6 @@ curl --location 'https://web3.binance.com/bapi/defi/v3/public/wallet-direct/buw/
 | Chain Name | chainId |
 |------------|---------|
 | BSC | 56 |
-| Ethereum | 1 |
 | Base | 8453 |
 | Solana | CT_501 |
 

--- a/skills/binance-web3/query-token-audit/SKILL.md
+++ b/skills/binance-web3/query-token-audit/SKILL.md
@@ -129,7 +129,7 @@ curl --location 'https://web3.binance.com/bapi/defi/v1/public/wallet-direct/secu
 | 0-1 | LOW | Proceed with caution | Lower risk detected, but NOT guaranteed safe. DYOR. |
 | 2-3 | MEDIUM | Exercise caution | Moderate risks detected, review risk items carefully |
 | 4 | HIGH | Avoid trading | Critical risks detected, high probability of loss |
-| 5 | BLOCKED | Block transaction | Severe risks confirmed, do NOT proceed |
+| 5 | HIGH | Block transaction | Severe risks confirmed, do NOT proceed |
 
 **IMPORTANT**: LOW risk does NOT mean "safe." Audit results are point-in-time snapshots. Project teams can modify contracts or restrict liquidity after purchase. These risks cannot be predicted in advance.
 


### PR DESCRIPTION
Remove unsupported Ethereum chain and correct risk level enum

- query-address-info: Remove Ethereum (chainId 1) from supported chains as the API does not support it
- query-token-audit: Change level 5 label from BLOCKED to HIGH to match actual API response