### PR TITLE
Add bnbchain-mcp skill and references

### DIFF
--- a/skills/bnbchain/bnbchain-mcp-skill/SKILL.md
+++ b/skills/bnbchain/bnbchain-mcp-skill/SKILL.md
@@ -1,0 +1,127 @@
+---
+title: bnbchain-mcp
+description: BNB Chain MCP server connection and tool usage. Covers npx @bnb-chain/mcp@latest, PRIVATE_KEY and RPC, and every MCP tool — blocks, transactions, contracts, ERC20/NFT transfers, wallet, ERC-8004 agent registration, Greenfield. Use when connecting to bnbchain-mcp, querying or transacting on BNB Chain/opBNB/EVM, registering as ERC-8004 agent, or using Greenfield.
+metadata:
+  version: 1.0.1
+  author: 0xlucasliao
+license: MIT
+---
+
+# BNB Chain MCP Skill
+
+How to connect to the BNB Chain MCP server and use its tools: blocks, transactions, contracts, tokens, NFTs, wallet, ERC-8004 agents, and Greenfield. Use this skill when working with BNB Chain / opBNB / EVM or Greenfield via MCP.
+
+---
+
+## Connection and credentials
+
+- **Run the server:** `npx @bnb-chain/mcp@latest` (fetches from npm at runtime). Source: [github.com/bnb-chain/bnbchain-mcp](https://github.com/bnb-chain/bnbchain-mcp).
+- **RPC:** Default chains use built-in RPC; no config unless self-hosting or custom RPC.
+- **PRIVATE_KEY:** Omit or leave empty for read-only (blocks, balances, contract reads). Set in the MCP server `env` for state-changing tools (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri, Greenfield writes). Never log or expose private keys.
+- **Read-only vs state-changing:** Block/balance/contract-read tools work without a key; transfers and writes require `PRIVATE_KEY` in the server environment.
+
+---
+
+## 1. MCP server config
+
+Add the `bnbchain-mcp` server to the MCP client config (e.g. Cursor MCP settings, Claude Desktop `claude_desktop_config.json`).
+
+**Default (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "bnbchain-mcp": {
+      "command": "npx",
+      "args": ["-y", "@bnb-chain/mcp@latest"],
+      "env": {
+        "PRIVATE_KEY": ""
+      }
+    }
+  }
+}
+```
+
+**SSE mode:** `"args": ["-y", "@bnb-chain/mcp@latest", "--sse"]` (and client SSE URL if required). **Local dev server** (e.g. `bun dev:sse` in bnbchain-mcp): `"url": "http://localhost:3001/sse"` with the same `env`.
+
+Restart or reload the MCP client after changing config so the server starts.
+
+---
+
+## 2. Credentials and environment
+
+- **RPC:** Built-in for default chains.
+- **PRIVATE_KEY:** Set in the server’s `env` when state-changing tools are needed; leave empty for read-only. Do not commit or echo keys.
+
+---
+
+## 3. Agent registration (ERC-8004)
+
+1. Register the agent on-chain with the MCP tool **`register_erc8004_agent`** (see [references/erc8004-tools-reference.md](references/erc8004-tools-reference.md)).
+2. Owners can then check registration on 8004scan (mainnet) or 8004scan (testnet).
+
+---
+
+## 4. Quick reference — tools and prompts
+
+### Network parameter
+
+- **Read-only tools** (blocks, balances, contract reads, get_chain_info, etc.): **`network`** is optional; default is `bsc`. Use **`get_supported_networks`** to list options.
+- **Write operations** (`transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract`, `register_erc8004_agent`, `set_erc8004_agent_uri`, Greenfield writes): **`network` is REQUIRED.** There is no default for writes. If the user does not specify the network, you **MUST ask** before calling the tool. Do not assume or default to mainnet (`bsc`); accidental mainnet execution causes irreversible financial loss.
+
+### Tool categories
+
+| Category | Examples | Needs PRIVATE_KEY? |
+|----------|----------|--------------------|
+| Blocks | `get_latest_block`, `get_block_by_number`, `get_block_by_hash` | No |
+| Transactions | `get_transaction`, `get_transaction_receipt`, `estimate_gas` | No (estimate only) |
+| Network | `get_chain_info`, `get_supported_networks` | No |
+| Wallet / balance | `get_native_balance`, `get_erc20_balance`, `get_address_from_private_key` | Balance: optional address or privateKey |
+| Transfers / writes | `transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract` | Yes |
+| Contracts | `read_contract`, `is_contract` | No for read |
+| Tokens / NFT | `get_erc20_token_info`, `get_nft_info`, `get_erc1155_token_metadata`, `check_nft_ownership`, `get_nft_balance`, `get_erc1155_balance` | No for read |
+| ERC-8004 | `register_erc8004_agent`, `set_erc8004_agent_uri`, `get_erc8004_agent`, `get_erc8004_agent_wallet` | Register/set_uri: Yes |
+| Greenfield | `gnfd_*` bucket/object/payment tools | Writes: Yes |
+
+### Prompts (MCP prompts)
+
+Use the MCP prompt names when the user wants analysis or guidance:
+
+- **analyze_block** — Analyze a block and its contents
+- **analyze_transaction** — Analyze a specific transaction
+- **analyze_address** — Analyze an EVM address
+- **interact_with_contract** — Guidance on interacting with a smart contract
+- **explain_evm_concept** — Explain an EVM concept
+- **compare_networks** — Compare EVM-compatible networks
+- **analyze_token** — Analyze an ERC20 or NFT token
+- **how_to_register_mcp_as_erc8004_agent** — Guidance on registering MCP as ERC-8004 agent
+
+---
+
+## 5. Reference files (per-tool usage)
+
+For **parameter names, examples, and detailed usage** of each tool, use:
+
+| Reference | Content |
+|-----------|---------|
+| [references/evm-tools-reference.md](references/evm-tools-reference.md) | Blocks, transactions, network, wallet, contracts, tokens, NFT — all EVM tools |
+| [references/erc8004-tools-reference.md](references/erc8004-tools-reference.md) | register_erc8004_agent, set_erc8004_agent_uri, get_erc8004_agent, get_erc8004_agent_wallet |
+| [references/greenfield-tools-reference.md](references/greenfield-tools-reference.md) | Buckets, objects, folders, payment accounts — all Greenfield tools |
+| [references/prompts-reference.md](references/prompts-reference.md) | All MCP prompts and when to use them |
+
+---
+
+## 6. Safety and best practices
+
+1. **Confirm before sending transactions:** For `transfer_*`, `write_contract`, or `approve_token_spending`, confirm recipient, amount, and network before calling the tool.
+2. **Network required for writes:** For any write (transfers, `write_contract`, `approve_token_spending`, ERC-8004 register/set_uri), you **MUST** have an explicit network from the user. If not specified, **ask** — do not default to mainnet. Do not use advisory language like "prefer testnet" as a substitute; the constraint is: no network specified → do not call the write tool until the user confirms.
+3. **Private keys:** Only in MCP server `env`; never in chat or logs.
+4. **ERC-8004 agentURI:** JSON metadata per the Agent Metadata Profile (name, description, image, services e.g. MCP endpoint).
+
+---
+
+## Documentation links
+
+- **BNB Chain MCP repo:** https://github.com/bnb-chain/bnbchain-mcp
+- **npm:** `npx @bnb-chain/mcp@latest`
+- **ERC-8004** (Identity Registry); **Agent Metadata Profile** for agentURI format.

--- a/skills/bnbchain/bnbchain-mcp-skill/references/erc8004-tools-reference.md
+++ b/skills/bnbchain/bnbchain-mcp-skill/references/erc8004-tools-reference.md
@@ -1,0 +1,62 @@
+# ERC-8004 agent tools reference
+
+Register and resolve AI agents on the ERC-8004 Identity Registry. Supported networks: BSC (56), BSC Testnet (97), Ethereum, Base, Polygon, and their testnets where the official registry is deployed.
+
+**agentURI** must point to a JSON metadata file following the Agent Metadata Profile: name, description, image, and `services` (e.g. MCP endpoint).
+
+---
+
+## register_erc8004_agent **(write)**
+
+Register an agent on the ERC-8004 Identity Registry. Mints an on-chain agent identity (NFT) and returns the agent ID.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| privateKey | string | Hex private key (or set `PRIVATE_KEY` in MCP env) |
+| agentURI | string | URI of agent metadata (e.g. `ipfs://...`, `https://...`, or `data:application/json,...`) |
+| network | string | **Required.** e.g. `bsc`, `bsc-testnet`, `ethereum`, `base`. No default — if user does not specify, ask before calling. Do not default to mainnet. |
+
+**Returns:** `agentId` (string), `txHash`, `network`.
+
+**Example:** After registration, owners can verify on 8004scan (mainnet or testnet).
+
+---
+
+## set_erc8004_agent_uri **(write)**
+
+Update the metadata URI for an existing ERC-8004 agent. Caller must be the owner of the agent NFT.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| privateKey | string | Owner’s private key |
+| agentId | string or number | ERC-8004 agent ID (token ID from the registry) |
+| newURI | string | New metadata URI (AgentURI format) |
+| network | string | **Required.** Network name or chain ID. No default for this write — ask if unspecified. |
+
+**Returns:** `success`, `txHash`, `agentId`, `network`.
+
+---
+
+## get_erc8004_agent **(read-only)**
+
+Get agent info from the ERC-8004 Identity Registry: owner address and tokenURI (metadata URI).
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| agentId | string or number | ERC-8004 agent ID (token ID) |
+| network | string | Network name or chain ID (optional; default `bsc`) |
+
+**Returns:** `agentId`, `owner`, `tokenURI`, `network`.
+
+---
+
+## get_erc8004_agent_wallet **(read-only)**
+
+Get the verified payment wallet address for an ERC-8004 agent (for x402 / agent payments). Set on-chain via setAgentWallet; defaults to owner on registration.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| agentId | string or number | ERC-8004 agent ID (token ID) |
+| network | string | Network name or chain ID (optional; default `bsc`) |
+
+**Returns:** `agentId`, `agentWallet`, `network`.

--- a/skills/bnbchain/bnbchain-mcp-skill/references/evm-tools-reference.md
+++ b/skills/bnbchain/bnbchain-mcp-skill/references/evm-tools-reference.md
@@ -1,0 +1,101 @@
+# EVM tools reference
+
+**`network`**: string like `bsc`, `opbnb`, `ethereum`, `base`, or chain ID. Use **get_supported_networks** to list options.
+
+- **Read-only tools:** `network` is optional; default is `bsc`.
+- **Write tools** (`transfer_native_token`, `transfer_erc20`, `transfer_nft`, `transfer_erc1155`, `approve_token_spending`, `write_contract`): **`network` is REQUIRED.** No default. If the user does not specify the network, the agent MUST ask before calling; do not default to mainnet.
+
+Tools that require **PRIVATE_KEY** in the MCP server env are marked with **(write)**.
+
+---
+
+## Blocks
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| get_latest_block | Get the latest block | `network` (optional) |
+| get_block_by_number | Get a block by number | `blockNumber` (string), `network` |
+| get_block_by_hash | Get a block by hash | `blockHash`, `network` |
+
+---
+
+## Transactions
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| get_transaction | Get transaction by hash | `txHash`, `network` |
+| get_transaction_receipt | Get receipt by hash | `txHash`, `network` |
+| estimate_gas | Estimate gas for a tx | `to`, `value` (optional, e.g. "0.1"), `data` (optional hex), `network` |
+
+---
+
+## Network
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| get_chain_info | Chain ID, block number, RPC URL | `network` |
+| get_supported_networks | List supported networks | (none) |
+
+---
+
+## Wallet and balances
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| get_address_from_private_key | Derive EVM address from private key | `privateKey` (or env PRIVATE_KEY) |
+| get_native_balance | Native token balance (BNB, ETH, etc.) | `address` (optional) or `privateKey`, `network` |
+| get_erc20_balance | ERC20 balance for an address | `tokenAddress`, `address`, `network` (and optionally `privateKey` for default address) |
+
+**(Write)** — require PRIVATE_KEY in env:
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| transfer_native_token | Send native token | `privateKey`, `toAddress`, `amount` (string e.g. "0.1"), `network` |
+| transfer_erc20 | Send ERC20 tokens | `privateKey`, `tokenAddress`, `toAddress`, `amount` (string), `network` |
+| approve_token_spending | Approve spender for ERC20 | `privateKey`, `tokenAddress`, `spenderAddress`, `amount` (string), `network` |
+| transfer_nft | Transfer ERC721 NFT | `privateKey`, `tokenAddress`, `tokenId`, `toAddress`, `network` |
+| transfer_erc1155 | Transfer ERC1155 | `privateKey`, `tokenAddress`, `tokenId`, `amount`, `toAddress`, `network` |
+
+---
+
+## Contracts
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| is_contract | Check if address is contract or EOA | `address`, `network` |
+| read_contract | Call view/pure function | `contractAddress`, `abi` (JSON array), `functionName`, `args` (optional array), `network` |
+| write_contract | **(Write)** Call state-changing function | `contractAddress`, `abi`, `functionName`, `args`, `privateKey` (or env), `network` |
+
+**read_contract:** Pass the ABI of the single function (or full contract ABI). Example args: `[]` or `["0x...", "123"]`.
+
+---
+
+## Tokens (ERC20)
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| get_erc20_token_info | Name, symbol, decimals | `tokenAddress`, `network` |
+
+---
+
+## NFT (ERC721 / ERC1155)
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| get_nft_info | ERC721 metadata, owner | `tokenAddress`, `tokenId`, `network` |
+| get_erc1155_token_metadata | ERC1155 token metadata | `tokenAddress`, `tokenId`, `network` |
+| check_nft_ownership | Whether address owns NFT | (Check with get_nft_info or contract read if available) |
+| get_nft_balance | NFT count for address in collection | (Use read_contract with balanceOf if needed) |
+| get_erc1155_balance | Balance of ERC1155 token ID for address | (Use read_contract with balanceOf if needed) |
+
+Transfer tools: see **Wallet and balances** above (`transfer_nft`, `transfer_erc1155`).
+
+---
+
+## ENS
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| resolve_ens | Resolve ENS name to address | `ensName`, `network` (typically ethereum) |
+
+Note: ENS is not supported on BSC; use on Ethereum or other chains where ENS is deployed.

--- a/skills/bnbchain/bnbchain-mcp-skill/references/greenfield-tools-reference.md
+++ b/skills/bnbchain/bnbchain-mcp-skill/references/greenfield-tools-reference.md
@@ -1,0 +1,51 @@
+# Greenfield tools reference
+
+Greenfield tools operate on **testnet** or **mainnet**. Use **`network`**: `"testnet"` (default) or `"mainnet"`. Writes require **PRIVATE_KEY** in the MCP server env (or passed where supported).
+
+**Note:** Some tools may be named differently in the implementation (e.g. file upload). Use the tool names exposed by the MCP server; below matches the [BNB Chain MCP README](https://github.com/bnb-chain/bnbchain-mcp) and common usage.
+
+---
+
+## Buckets
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| gnfd_list_buckets | List buckets owned by an address | `network`, `address` (optional), `privateKey` (optional for default account) |
+| gnfd_get_bucket_info | Bucket details | `network`, `bucketName` |
+| gnfd_get_bucket_full_info | Bucket info and quota usage | `network`, `bucketName`, `privateKey` |
+| gnfd_create_bucket | **(Write)** Create a bucket | `network`, `privateKey`, `bucketName` |
+| gnfd_delete_bucket | **(Write)** Delete a bucket | `network`, `privateKey`, `bucketName` |
+
+**bucketName** defaults to `created-by-bnbchain-mcp` when optional.
+
+---
+
+## Objects and folders
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| gnfd_list_objects | List objects in a bucket | `network`, `bucketName` |
+| gnfd_get_object_info | Object details | `network`, `bucketName`, `objectName` |
+| gnfd_upload_object / gnfd_create_file | **(Write)** Upload a file to a bucket | `network`, `privateKey`, `filePath` (absolute path to file), `bucketName` |
+| gnfd_download_object | Download object to disk | `network`, `bucketName`, `objectName`, `targetPath` (optional), `privateKey` |
+| gnfd_delete_object | **(Write)** Delete an object | `network`, `privateKey`, `bucketName`, `objectName` |
+| gnfd_create_folder | **(Write)** Create a folder in a bucket | `network`, `privateKey`, `bucketName`, `folderName` (optional) |
+
+If the server exposes **gnfd_create_file** instead of **gnfd_upload_object**, use **filePath** (absolute path to the file to upload).
+
+---
+
+## Account and payment
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| gnfd_get_account_balance | Balance for a Greenfield account | `network`, address/privateKey as per implementation |
+| gnfd_get_payment_accounts | Payment accounts for an address | `network`, `address` (optional), `privateKey` |
+| gnfd_get_payment_account_info | Details of a payment account | `network`, account identifier (see implementation) |
+| gnfd_create_payment | **(Write)** Create a payment account | `network`, `privateKey` |
+| gnfd_get_payment_balance | Payment account balance | `network`, account identifier |
+| gnfd_deposit_to_payment | **(Write)** Deposit into payment account | `network`, `to` (payment account address), `amount` (string, in BNB), `privateKey` |
+| gnfd_withdraw_from_payment | **(Write)** Withdraw from payment account | `network`, `from`, `amount`, `privateKey` |
+| gnfd_disable_refund | **(Write, IRREVERSIBLE)** Disable refund for payment account | `network`, `address`, `privateKey` (if exposed) |
+
+Use **get_supported_networks** or the MCP server’s tool list to confirm exact parameter names for the version in use.

--- a/skills/bnbchain/bnbchain-mcp-skill/references/prompts-reference.md
+++ b/skills/bnbchain/bnbchain-mcp-skill/references/prompts-reference.md
@@ -1,0 +1,16 @@
+# MCP prompts reference
+
+The BNB Chain MCP server exposes **prompts** that return guided analysis or explanations. Use these prompt names when invoking MCP prompts (e.g. from Cursor or Claude).
+
+| Prompt name | When to use |
+|-------------|-------------|
+| **analyze_block** | User wants detailed information about a block (transactions, gas, etc.). |
+| **analyze_transaction** | User wants analysis of a specific transaction (hash). |
+| **analyze_address** | User wants analysis of an EVM address (balances, contracts, activity). |
+| **interact_with_contract** | User needs guidance on how to interact with a smart contract (read/write, ABI, params). |
+| **explain_evm_concept** | User asks about an EVM concept (gas, opcodes, ABI, etc.). |
+| **compare_networks** | User wants to compare EVM-compatible networks (BSC, opBNB, Ethereum, etc.). |
+| **analyze_token** | User wants to analyze an ERC20 or NFT token (metadata, supply, etc.). |
+| **how_to_register_mcp_as_erc8004_agent** | User wants step-by-step guidance on registering an MCP server as an ERC-8004 agent. |
+
+Prompts typically accept input (e.g. block number, tx hash, address) as specified by the MCP server. Prefer these prompts when the user asks for “analysis,” “explanation,” or “how to” rather than a single raw tool call.


### PR DESCRIPTION
Add a new BNB Chain MCP skill with usage documentation and per-tool references. Files added: SKILL.md (connection, server config, credentials, prompts, tool categories, safety/best practices) and four detailed references: evm-tools-reference.md (blocks, txs, contracts, tokens, wallet, transfers), erc8004-tools-reference.md (agent registration and agent wallet APIs), greenfield-tools-reference.md (bucket/object/payment Greenfield tools), and prompts-reference.md (MCP prompt names and use cases). This provides guidance for connecting to npx @bnb-chain/mcp, read vs write operations, PRIVATE_KEY handling, required network for writes, and examples for common MCP operations.