### PR TITLE
Add DeFi Yield Radar skill — DeFi yield pool scanner for BSC (BNB Chain). Fetches real-time yield data from D

### DIFF
--- a/skills/binance-web3/defi-yield-radar/SKILL.md
+++ b/skills/binance-web3/defi-yield-radar/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: defi-yield-radar
+description: |
+  DeFi yield pool scanner for BSC (BNB Chain). Fetches real-time yield data from DefiLlama,
+  filters for BSC pools, and presents APY, TVL, IL risk, and stablecoin classification.
+  Use this skill when users ask about DeFi yields, farming opportunities, APY comparisons,
+  yield farming on BSC, or stablecoin yield strategies.
+metadata:
+  author: binance-web3-team
+  version: "1.0"
+---
+
+# DeFi Yield Radar Skill
+
+## Overview
+
+Scans all DeFi yield pools on BSC via the DefiLlama Yields API, providing a sortable,
+filterable view of farming opportunities ranked by APY and TVL.
+
+## Data Source
+
+| Source | Endpoint | TTL |
+|--------|----------|-----|
+| DefiLlama | `https://yields.llama.fi/pools` | 120s |
+
+## Fields
+
+| Field | Description |
+|-------|-------------|
+| project | Protocol name (e.g., PancakeSwap, Venus) |
+| symbol | Pool pair symbol (e.g., CAKE-BNB) |
+| apy | Total APY (base + reward) |
+| apyBase | Base APY from trading fees |
+| apyReward | Reward APY from token emissions |
+| tvlUsd | Total value locked in USD |
+| ilRisk | Impermanent loss risk flag |
+| stablecoin | Whether pool contains stablecoins |
+| chain | Blockchain (filtered to BSC) |
+
+## Filters
+
+- **All**: Show all BSC pools with TVL > $10K
+- **Stablecoin**: Only pools containing stablecoins (lower risk)
+- **No IL**: Only pools with no impermanent loss risk
+
+## Usage Examples
+
+- "Show me the highest yield pools on BSC"
+- "What stablecoin farming options are on BNB Chain?"
+- "Find BSC pools with no impermanent loss"

--- a/skills/binance-web3/defi-yield-radar/SKILL.md
+++ b/skills/binance-web3/defi-yield-radar/SKILL.md
@@ -1,13 +1,14 @@
 ---
-name: defi-yield-radar
+title: DeFi Yield Radar
 description: |
   DeFi yield pool scanner for BSC (BNB Chain). Fetches real-time yield data from DefiLlama,
   filters for BSC pools, and presents APY, TVL, IL risk, and stablecoin classification.
   Use this skill when users ask about DeFi yields, farming opportunities, APY comparisons,
   yield farming on BSC, or stablecoin yield strategies.
 metadata:
-  author: binance-web3-team
   version: "1.0"
+  author: mefai-dev
+license: MIT
 ---
 
 # DeFi Yield Radar Skill

--- a/skills/binance-web3/defi-yield-radar/SKILL.md
+++ b/skills/binance-web3/defi-yield-radar/SKILL.md
@@ -1,12 +1,12 @@
 ---
-title: DeFi Yield Radar
+name: defi-yield-radar
 description: |
   DeFi yield pool scanner for BSC (BNB Chain). Fetches real-time yield data from DefiLlama,
   filters for BSC pools, and presents APY, TVL, IL risk, and stablecoin classification.
   Use this skill when users ask about DeFi yields, farming opportunities, APY comparisons,
   yield farming on BSC, or stablecoin yield strategies.
 metadata:
-  version: "1.0"
+  version: "1.0.0"
   author: mefai-dev
 license: MIT
 ---
@@ -20,32 +20,35 @@ filterable view of farming opportunities ranked by APY and TVL.
 
 ## Data Source
 
-| Source | Endpoint | TTL |
-|--------|----------|-----|
-| DefiLlama | `https://yields.llama.fi/pools` | 120s |
+| Endpoint | Description |
+|----------|-------------|
+| `https://yields.llama.fi/pools` (GET) | Fetches all DeFi yield pools across chains |
 
-## Fields
+## How It Works
 
-| Field | Description |
-|-------|-------------|
-| project | Protocol name (e.g., PancakeSwap, Venus) |
-| symbol | Pool pair symbol (e.g., CAKE-BNB) |
-| apy | Total APY (base + reward) |
-| apyBase | Base APY from trading fees |
-| apyReward | Reward APY from token emissions |
-| tvlUsd | Total value locked in USD |
-| ilRisk | Impermanent loss risk flag |
-| stablecoin | Whether pool contains stablecoins |
-| chain | Blockchain (filtered to BSC) |
+1. Fetches all pools from DefiLlama Yields API
+2. Filters for BSC (BNB Chain) pools only
+3. Sorts by APY descending
+4. Classifies pools by stablecoin status and IL risk
+5. Presents top pools with APY, TVL, project name, and risk indicators
 
-## Filters
-
-- **All**: Show all BSC pools with TVL > $10K
-- **Stablecoin**: Only pools containing stablecoins (lower risk)
-- **No IL**: Only pools with no impermanent loss risk
-
-## Usage Examples
+## Example Prompts
 
 - "Show me the highest yield pools on BSC"
 - "What stablecoin farming options are on BNB Chain?"
 - "Find BSC pools with no impermanent loss"
+- "Compare APY across BSC DeFi protocols"
+- "Which BSC pools have TVL over $1M?"
+
+## Output Format
+
+| Pool | Project | APY | TVL | IL Risk | Stablecoin |
+|------|---------|-----|-----|---------|------------|
+| USDT-USDC | PancakeSwap | 12.5% | $45M | No | Yes |
+| BNB-BUSD | Venus | 8.2% | $120M | Yes | No |
+
+## Tech Stack
+
+- JavaScript (ES6+)
+- DefiLlama Yields API
+- No API key required


### PR DESCRIPTION
## Summary

DeFi yield pool scanner for BSC (BNB Chain). Fetches real-time yield data from DefiLlama, filters for BSC pools, and presents APY, TVL, IL risk, and stablecoin classification. Use this skill when users ask about DeFi yields, farming opportunities, APY comparisons, yield farming on BSC, or stablecoin yield strategies.

## Endpoints Used

| Endpoint | Description |
|----------|-------------|
| `https://yields.llama.fi/pools` (GET) | API data |

## How It Works

1. "Show me the highest yield pools on BSC"
2. "What stablecoin farming options are on BNB Chain?"
3. "Find BSC pools with no impermanent loss"