### PR TITLE
Add Stablecoin Flow Tracker skill — Cross-chain stablecoin supply tracker. Shows stablecoin circulating supply on BS

### DIFF
--- a/skills/binance-web3/stablecoin-flow-tracker/SKILL.md
+++ b/skills/binance-web3/stablecoin-flow-tracker/SKILL.md
@@ -1,13 +1,14 @@
 ---
-name: stablecoin-flow-tracker
+title: Stablecoin Flow Tracker
 description: |
   Cross-chain stablecoin supply tracker. Shows stablecoin circulating supply on BSC vs other chains,
   with chain distribution visualization and per-stablecoin breakdown.
   Use this skill when users ask about stablecoin flows, USDT/USDC supply on BSC,
   cross-chain stablecoin movement, or chain liquidity comparisons.
 metadata:
-  author: binance-web3-team
   version: "1.0"
+  author: mefai-dev
+license: MIT
 ---
 
 # Stablecoin Flow Tracker Skill

--- a/skills/binance-web3/stablecoin-flow-tracker/SKILL.md
+++ b/skills/binance-web3/stablecoin-flow-tracker/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: stablecoin-flow-tracker
+description: |
+  Cross-chain stablecoin supply tracker. Shows stablecoin circulating supply on BSC vs other chains,
+  with chain distribution visualization and per-stablecoin breakdown.
+  Use this skill when users ask about stablecoin flows, USDT/USDC supply on BSC,
+  cross-chain stablecoin movement, or chain liquidity comparisons.
+metadata:
+  author: binance-web3-team
+  version: "1.0"
+---
+
+# Stablecoin Flow Tracker Skill
+
+## Overview
+
+Tracks stablecoin circulating supply across chains using DefiLlama's Stablecoins API.
+Focuses on BSC allocation with cross-chain comparison.
+
+## Data Sources
+
+| Source | Endpoint | TTL |
+|--------|----------|-----|
+| DefiLlama | `https://stablecoins.llama.fi/stablecoins?includePrices=true` | 300s |
+| DefiLlama | `https://stablecoins.llama.fi/stablecoinchains` | 300s |
+
+## Display Components
+
+### Summary Cards
+- BSC total stablecoin supply
+- Number of stablecoins on BSC
+- Top stablecoin on BSC
+
+### Chain Distribution Bar
+Colored horizontal bar showing proportional stablecoin supply across top chains
+(Ethereum, BSC, Tron, Solana, etc.)
+
+### Per-Stablecoin Table
+| Field | Description |
+|-------|-------------|
+| symbol | Stablecoin ticker (USDT, USDC, etc.) |
+| bscCirculating | Circulating supply on BSC |
+| totalCirculating | Total supply across all chains |
+| bscPct | BSC share of total supply |
+| pegMechanism | Peg type (fiat-backed, algorithmic, etc.) |
+
+## Usage Examples
+
+- "How much USDT is on BSC?"
+- "Compare stablecoin supply across chains"
+- "Show BSC stablecoin market share"


### PR DESCRIPTION
## Summary

Cross-chain stablecoin supply tracker. Shows stablecoin circulating supply on BSC vs other chains, with chain distribution visualization and per-stablecoin breakdown. Use this skill when users ask about stablecoin flows, USDT/USDC supply on BSC, cross-chain stablecoin movement, or chain liquidity comparisons.

## Endpoints Used

| Endpoint | Description |
|----------|-------------|
| `https://stablecoins.llama.fi/stablecoins` (GET) | API data |
| `https://stablecoins.llama.fi/stablecoinchains` (GET) | API data |

## How It Works

1. "How much USDT is on BSC?"
2. "Compare stablecoin supply across chains"
3. "Show BSC stablecoin market share"

## Use Cases

- **Summary Cards**
- BSC total stablecoin supply
- Number of stablecoins on BSC
- Top stablecoin on BSC
- **Chain Distribution Bar**