### PR TITLE
Add dca-backtester skill — DCA strategy simulation with lump-sum comparison

### DIFF
--- a/skills/binance-web3/capital-rotation/SKILL.md
+++ b/skills/binance-web3/capital-rotation/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: capital-rotation
+description: |
+  Track capital flow between crypto sectors in real-time. Detect when smart money
+  rotates from Meme → AI → RWA → DePIN by monitoring sector-level market cap changes,
+  volume shifts, and momentum. Uses CoinGecko Categories API (free, no auth).
+metadata:
+  author: mefai-dev
+  version: "1.0"
+---
+
+# Capital Rotation Radar
+
+## Overview
+
+| Source | Data | Free |
+|--------|------|------|
+| CoinGecko Categories API | Sector market caps, 24h volume, 24h% change | Yes, no auth |
+| CoinGecko Markets API | Individual coins per sector with full market data | Yes, no auth |
+
+## Use Cases
+
+1. **Sector Rotation Detection** — "AI sector gained $2B in 24h while Meme lost $1.5B" — capital is rotating
+2. **Narrative Momentum** — Which sectors have the strongest inflows right now?
+3. **Contrarian Signals** — Sectors with massive outflows may be bottoming — mean reversion opportunity
+4. **Portfolio Rebalancing** — Align your portfolio with the macro capital flow direction
+5. **Early Narrative Entry** — Detect rising sectors before they become mainstream narratives
+
+## Key Sectors to Track
+
+| Category ID | Name | Why |
+|-------------|------|-----|
+| `meme-token` | Meme | Retail sentiment proxy, first to pump/dump |
+| `ai-agents` | AI Agents | Hottest narrative, institutional interest |
+| `ai-meme-coins` | AI Meme | Intersection of AI + meme narratives |
+| `real-world-assets-rwa` | RWA | Institutional flow indicator |
+| `depin` | DePIN | Infrastructure narrative |
+| `gaming` | Gaming / GameFi | Retail engagement proxy |
+| `layer-1` | Layer 1 | Infrastructure capital flow |
+| `layer-2` | Layer 2 | Scaling narrative |
+| `decentralized-finance-defi` | DeFi | TVL-driven capital flow |
+| `smart-contract-platform` | Smart Contract Platforms | Ecosystem capital rotation |
+| `stablecoins` | Stablecoins | Flight-to-safety indicator |
+
+---
+
+## API 1: All Categories with Market Data
+
+Returns all 750+ crypto categories with aggregated market data. One call gives you the entire sector map.
+
+### Request
+
+```
+GET https://api.coingecko.com/api/v3/coins/categories
+```
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `order` | string | No | `market_cap_desc` | Sort: `market_cap_desc`, `market_cap_asc`, `market_cap_change_24h_desc`, `market_cap_change_24h_asc`, `name_desc`, `name_asc` |
+
+### Example Request
+
+```bash
+curl "https://api.coingecko.com/api/v3/coins/categories?order=market_cap_change_24h_desc"
+```
+
+### Response
+
+```json
+[
+  {
+    "id": "ai-agents",
+    "name": "AI Agents",
+    "market_cap": 8945123456.78,
+    "market_cap_change_24h": 12.45,
+    "content": "AI agent tokens enable autonomous...",
+    "top_3_coins": [
+      "https://coin-images.coingecko.com/coins/images/.../small/token.png"
+    ],
+    "top_3_coins_id": ["virtuals-protocol", "ai16z", "fartcoin"],
+    "volume_24h": 2345678901.23,
+    "updated_at": "2026-03-04T16:15:30.019Z"
+  }
+]
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Category slug (use as filter in markets API) |
+| `name` | string | Human-readable category name |
+| `market_cap` | number | Total sector market cap in USD |
+| `market_cap_change_24h` | number | 24h market cap change as percentage |
+| `volume_24h` | number | Total 24h trading volume in USD |
+| `top_3_coins` | string[] | Image URLs for top 3 coins |
+| `top_3_coins_id` | string[] | CoinGecko IDs of top 3 coins |
+| `content` | string/null | Category description |
+| `updated_at` | string | ISO 8601 timestamp |
+
+---
+
+## API 2: Category ID List (Lightweight)
+
+Returns just IDs and names — useful for building category selectors.
+
+### Request
+
+```
+GET https://api.coingecko.com/api/v3/coins/categories/list
+```
+
+### Response
+
+```json
+[
+  {"category_id": "meme-token", "name": "Meme"},
+  {"category_id": "ai-agents", "name": "AI Agents"},
+  {"category_id": "real-world-assets-rwa", "name": "Real World Assets (RWA)"},
+  {"category_id": "depin", "name": "DePIN"}
+]
+```
+
+**Total:** ~756 categories available.
+
+---
+
+## API 3: Coins Within a Category
+
+Returns individual coins for a specific sector with full market data.
+
+### Request
+
+```
+GET https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&category={category_id}
+```
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `vs_currency` | string | Yes | — | Target currency (`usd`, `btc`, `eur`) |
+| `category` | string | Yes | — | Category slug from categories API |
+| `order` | string | No | `market_cap_desc` | Sort order |
+| `per_page` | int | No | 100 | Results per page (max 250) |
+| `page` | int | No | 1 | Page number |
+| `sparkline` | bool | No | false | Include 7-day sparkline |
+
+### Example Request
+
+```bash
+curl "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&category=ai-agents&per_page=10&page=1"
+```
+
+### Response
+
+```json
+[
+  {
+    "id": "virtuals-protocol",
+    "symbol": "virtual",
+    "name": "Virtuals Protocol",
+    "image": "https://coin-images.coingecko.com/coins/images/.../small/virtual.png",
+    "current_price": 1.23,
+    "market_cap": 1234567890,
+    "market_cap_rank": 85,
+    "total_volume": 234567890,
+    "price_change_percentage_24h": 15.67,
+    "market_cap_change_percentage_24h": 14.23,
+    "circulating_supply": 1000000000,
+    "ath": 5.07,
+    "ath_change_percentage": -75.2,
+    "atl": 0.0089,
+    "atl_change_percentage": 13720.0
+  }
+]
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | CoinGecko coin ID |
+| `symbol` | string | Token ticker |
+| `name` | string | Token name |
+| `image` | string | Token icon URL |
+| `current_price` | number | Current price in USD |
+| `market_cap` | number | Market cap in USD |
+| `market_cap_rank` | number | Global rank |
+| `total_volume` | number | 24h trading volume |
+| `price_change_percentage_24h` | number | 24h price change % |
+| `market_cap_change_percentage_24h` | number | 24h market cap change % |
+| `circulating_supply` | number | Circulating supply |
+| `ath` | number | All-time high price |
+| `ath_change_percentage` | number | % from ATH |
+
+---
+
+## Rotation Detection Algorithm
+
+### Step 1: Fetch Sector Snapshots
+
+Call `/coins/categories` to get all sectors with market cap and 24h change.
+
+### Step 2: Filter Key Sectors
+
+Track these 10 core sectors:
+
+```
+SECTORS = [
+  "meme-token", "ai-agents", "ai-meme-coins",
+  "real-world-assets-rwa", "depin", "gaming",
+  "layer-1", "layer-2", "decentralized-finance-defi",
+  "smart-contract-platform"
+]
+```
+
+### Step 3: Calculate Flow Signals
+
+For each sector, compute:
+- **Momentum** = `market_cap_change_24h` (positive = inflow, negative = outflow)
+- **Volume Intensity** = `volume_24h / market_cap` (higher = more active trading)
+- **Flow Direction** = momentum > 0 → INFLOW, momentum < 0 → OUTFLOW
+
+### Step 4: Rotation Matrix
+
+```
+| From          | To            | Signal Strength |
+|---------------|---------------|-----------------|
+| Meme (-8.5%)  | AI (+12.4%)   | STRONG          |
+| DeFi (-3.2%)  | RWA (+6.1%)   | MODERATE        |
+| Gaming (-1.5%)| DePIN (+4.2%) | MODERATE        |
+```
+
+**Signal Strength:**
+- Strong: both sectors > 5% absolute change in opposite directions
+- Moderate: both sectors > 2% absolute change
+- Weak: smaller movements
+
+### Step 5: Narrative Score (0-100)
+
+```
+For each sector:
+  base = market_cap_change_24h (capped at ±20)
+  volume_boost = min(10, volume_intensity × 100)
+  narrative_score = 50 + (base × 2.5) + volume_boost
+  clamp(0, 100)
+```
+
+---
+
+## Recipes
+
+### Recipe 1: Sector Rotation Dashboard
+
+```
+Show current capital rotation across crypto sectors:
+1. Fetch /coins/categories
+2. Filter to 10 key sectors
+3. Sort by market_cap_change_24h
+4. Display: Sector name | MCap | 24h Change% | Volume | Flow Direction (↑/↓)
+5. Color: green for inflow, red for outflow
+6. Show rotation arrows between top gainer and top loser
+```
+
+### Recipe 2: Sector Deep Dive
+
+```
+Analyze {sector} in detail:
+1. Fetch /coins/categories for sector overview
+2. Fetch /coins/markets?category={sector_id} for top 20 coins
+3. Show: sector total MCap, volume, 24h change
+4. List top performers and worst performers within sector
+5. Calculate sector concentration (top 3 coins % of total)
+```
+
+### Recipe 3: Narrative Momentum Alert
+
+```
+Find sectors with strongest momentum right now:
+1. Fetch /coins/categories?order=market_cap_change_24h_desc
+2. Take top 5 gaining sectors and bottom 5 losing sectors
+3. For top gainers: "Capital flowing INTO: AI Agents (+12%), RWA (+6%)"
+4. For top losers: "Capital flowing OUT OF: Meme (-8%), Gaming (-4%)"
+5. Calculate rotation pairs (money leaving X is entering Y)
+```
+
+### Recipe 4: Contrarian Signal
+
+```
+Find sectors that may be bottoming for mean reversion:
+1. Fetch /coins/categories?order=market_cap_change_24h_asc
+2. Take bottom 5 sectors (biggest losers)
+3. For each, fetch /coins/markets to find individual coins near ATL
+4. Flag sectors where volume is increasing despite price dropping (accumulation signal)
+5. "Contrarian opportunity: {sector} down -12% but volume up 45%"
+```
+
+---
+
+## Rate Limits
+
+| Aspect | Limit |
+|--------|-------|
+| Calls/minute | 30 (free tier) |
+| Monthly cap | ~10,000 calls |
+| Cache TTL | 30 seconds (server-side) |
+| Rate exceeded | HTTP 429 with `retry-after: 60` |
+
+## Notes
+
+- CoinGecko Categories API is completely free, no API key required
+- Base URL: `https://api.coingecko.com/api/v3/` (free tier)
+- Optional: register for free Demo API key for better rate limit tracking
+- If using Demo key: pass via `x-cg-demo-api-key` header
+- The `/coins/categories` endpoint returns ALL 750+ categories in one call — cache aggressively
+- `market_cap_change_24h` is the key field for rotation detection
+- Categories update every ~5 minutes
+- For the rotation radar, calling `/coins/categories` once every 5 minutes uses only ~288 calls/day
+- CORS headers present (`access-control-allow-origin: *`) — works from browser

--- a/skills/binance-web3/contract-mutation/SKILL.md
+++ b/skills/binance-web3/contract-mutation/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: contract-mutation
+description: |
+  Monitor proxy/upgradeable smart contracts for mutations — detect when a "safe" contract
+  gets upgraded with dangerous new functions (mint, blacklist, setTax). Combines Etherscan V2 API
+  (proxy detection, source code, ABI) with GoPlus Security (runtime safety checks).
+  Bridges the gap between one-time audits and ongoing contract monitoring.
+metadata:
+  author: mefai-dev
+  version: "1.0"
+---
+
+# Contract Mutation Monitor
+
+## Overview
+
+| Source | Data | Free |
+|--------|------|------|
+| Etherscan V2 API | Proxy detection, implementation address, source code, ABI | Yes (verified contract endpoints) |
+| GoPlus Security API | is_proxy, owner, mintable, honeypot, tax, blacklist | Yes, no auth |
+
+## Use Cases
+
+1. **Proxy Upgrade Alert** — Detect when a proxy contract's implementation changes to a new address
+2. **Dangerous Function Detection** — Scan new implementations for `mint()`, `blacklist()`, `setTax()`, `pause()`, `selfdestruct()`
+3. **Owner Activity Monitoring** — Track ownership transfers, admin calls, and permission changes
+4. **Trust Decay Score** — Quantify how much a contract's safety has degraded since deployment
+5. **Pre-Buy Safety Check** — Before buying a token, check if its contract is upgradeable and what the current risks are
+
+## Supported Chains
+
+| Chain | Etherscan chainId | GoPlus chainId |
+|-------|-------------------|----------------|
+| BSC | `56` | `56` |
+| Ethereum | `1` | `1` |
+| Base | `8453` | `8453` |
+| Arbitrum | `42161` | `42161` |
+| Polygon | `137` | `137` |
+| Avalanche | `43114` | `43114` |
+| Optimism | `10` | `10` |
+
+---
+
+## API 1: Etherscan V2 — Get Source Code + Proxy Detection
+
+Returns contract source code, ABI, compiler info, and critically — **proxy status and implementation address**.
+
+### Request
+
+```
+GET https://api.etherscan.io/v2/api?chainid={chainId}&module=contract&action=getsourcecode&address={address}&apikey={apiKey}
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `chainid` | string | Yes | Chain ID (`56`, `1`, `8453`, etc.) |
+| `module` | string | Yes | `contract` |
+| `action` | string | Yes | `getsourcecode` |
+| `address` | string | Yes | Contract address |
+| `apikey` | string | Yes | Etherscan API key (free tier) |
+
+### Example Request
+
+```bash
+curl "https://api.etherscan.io/v2/api?chainid=56&module=contract&action=getsourcecode&address=0x...&apikey=YOUR_KEY"
+```
+
+### Response
+
+```json
+{
+  "status": "1",
+  "message": "OK",
+  "result": [
+    {
+      "SourceCode": "pragma solidity ^0.8.0; ...",
+      "ABI": "[{\"inputs\":[], ...}]",
+      "ContractName": "TransparentUpgradeableProxy",
+      "CompilerVersion": "v0.8.17+commit.8df45f5f",
+      "OptimizationUsed": "1",
+      "Runs": "200",
+      "Proxy": "1",
+      "Implementation": "0x1234...abcd",
+      "LicenseType": "MIT",
+      "SimilarMatch": ""
+    }
+  ]
+}
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SourceCode` | string | Solidity source code |
+| `ABI` | string | ABI as JSON string (needs `JSON.parse()`) |
+| `ContractName` | string | Contract name |
+| `CompilerVersion` | string | Compiler version |
+| **`Proxy`** | **string** | **`"1"` = proxy contract, `"0"` = not proxy** |
+| **`Implementation`** | **string** | **Implementation contract address (when Proxy="1")** |
+| `LicenseType` | string | SPDX license |
+| `SimilarMatch` | string | Address of similar verified contract |
+
+### Proxy Detection
+
+When `Proxy == "1"`:
+1. The `address` is the proxy (storage layer)
+2. The `Implementation` field contains the logic contract address
+3. Call `getsourcecode` again with the `Implementation` address to get the actual logic ABI
+4. Compare ABIs between the proxy and implementation to detect mutations
+
+### Proxy Pattern Names (from ContractName)
+
+| ContractName Pattern | Standard |
+|---------------------|----------|
+| `TransparentUpgradeableProxy` | EIP-1967 (OpenZeppelin) |
+| `ERC1967Proxy` | EIP-1967 |
+| `AdminUpgradeabilityProxy` | OpenZeppelin legacy |
+| `BeaconProxy` | Beacon pattern |
+| `UUPSUpgradeable` | EIP-1822 |
+
+---
+
+## API 2: Etherscan V2 — Get ABI
+
+Returns just the ABI for a verified contract. Use to compare implementation ABIs.
+
+### Request
+
+```
+GET https://api.etherscan.io/v2/api?chainid={chainId}&module=contract&action=getabi&address={address}&apikey={apiKey}
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `chainid` | string | Yes | Chain ID |
+| `module` | string | Yes | `contract` |
+| `action` | string | Yes | `getabi` |
+| `address` | string | Yes | Contract address |
+| `apikey` | string | Yes | Etherscan API key |
+
+### Response
+
+```json
+{
+  "status": "1",
+  "message": "OK",
+  "result": "[{\"constant\":false,\"inputs\":[...],\"name\":\"transfer\",\"outputs\":[...],\"type\":\"function\"}]"
+}
+```
+
+The `result` is a JSON string containing the ABI array. Parse with `JSON.parse()`.
+
+---
+
+## API 3: GoPlus Security — Runtime Safety Check
+
+Complements Etherscan's static analysis with runtime safety checks.
+
+### Request
+
+```
+GET https://api.gopluslabs.io/api/v1/token_security/{chainId}?contract_addresses={address}
+```
+
+### Mutation-Related Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_proxy` | string | `"1"` = proxy contract (upgradeable) |
+| `is_mintable` | string | `"1"` = new tokens can be minted |
+| `is_honeypot` | string | `"1"` = cannot sell (buy trap) |
+| `owner_change_balance` | string | `"1"` = owner can modify balances |
+| `can_take_back_ownership` | string | `"1"` = ownership can be reclaimed after renouncing |
+| `hidden_owner` | string | `"1"` = hidden owner mechanism |
+| `selfdestruct` | string | `"1"` = contract can self-destruct |
+| `external_call` | string | `"1"` = makes external calls (risk) |
+| `transfer_pausable` | string | `"1"` = transfers can be paused |
+| `is_blacklisted` | string | `"1"` = has blacklist function |
+| `slippage_modifiable` | string | `"1"` = slippage can be changed |
+| `is_anti_whale` | string | `"1"` = has anti-whale limits |
+| `anti_whale_modifiable` | string | `"1"` = anti-whale limits can be changed |
+| `buy_tax` | string | Buy tax rate (0-1) |
+| `sell_tax` | string | Sell tax rate (0-1) |
+| `owner_address` | string | Current owner address |
+| `creator_address` | string | Contract deployer |
+| `is_open_source` | string | `"1"` = source code verified |
+
+---
+
+## Dangerous Function Detection
+
+### Critical Functions to Flag
+
+When analyzing an implementation ABI, scan for these function signatures:
+
+| Function | Risk Level | Description |
+|----------|-----------|-------------|
+| `mint(address,uint256)` | HIGH | Can create new tokens (inflation) |
+| `blacklist(address)` / `addBlacklist` | HIGH | Can block addresses from selling |
+| `setTaxFee` / `setFee` / `updateFee` | HIGH | Can change tax to 99% |
+| `pause()` / `unpause()` | HIGH | Can freeze all transfers |
+| `selfdestruct` / `delegatecall` | CRITICAL | Can destroy or redirect contract |
+| `setMaxTx` / `setMaxWallet` | MEDIUM | Can restrict trading amounts |
+| `excludeFromFee` | MEDIUM | Owner can exempt addresses from tax |
+| `renounceOwnership` | INFO | Gives up control (positive if called) |
+| `transferOwnership` | MEDIUM | Can transfer control to new address |
+| `upgradeTo` / `upgradeToAndCall` | HIGH | Can change implementation (proxy) |
+
+### ABI Scanning Algorithm
+
+```python
+DANGEROUS_SIGS = {
+    "mint": "CRITICAL",
+    "blacklist": "CRITICAL",
+    "addBlacklist": "CRITICAL",
+    "setTax": "HIGH",
+    "setFee": "HIGH",
+    "updateFee": "HIGH",
+    "pause": "HIGH",
+    "selfdestruct": "CRITICAL",
+    "upgradeTo": "HIGH",
+    "upgradeToAndCall": "HIGH",
+    "setMaxTx": "MEDIUM",
+    "setMaxWallet": "MEDIUM",
+    "excludeFromFee": "MEDIUM",
+    "transferOwnership": "MEDIUM",
+}
+
+def scan_abi(abi_json):
+    findings = []
+    for item in abi_json:
+        if item.get("type") != "function":
+            continue
+        name = item.get("name", "")
+        for sig, level in DANGEROUS_SIGS.items():
+            if sig.lower() in name.lower():
+                findings.append({
+                    "function": name,
+                    "risk": level,
+                    "inputs": [i["type"] for i in item.get("inputs", [])],
+                })
+    return findings
+```
+
+---
+
+## Trust Decay Score (0-100)
+
+Start at 100 (fully trusted), subtract for each risk factor:
+
+| Risk Factor | Deduction | Source |
+|-------------|-----------|--------|
+| Is proxy (upgradeable) | -15 | Etherscan `Proxy` field |
+| Has `mint()` function | -15 | ABI scan |
+| Has `blacklist()` function | -15 | ABI scan |
+| Has `setTax/setFee` function | -10 | ABI scan |
+| Has `pause()` function | -10 | ABI scan |
+| Has `selfdestruct` | -20 | ABI scan / GoPlus |
+| Owner can change balance | -15 | GoPlus `owner_change_balance` |
+| Can take back ownership | -10 | GoPlus `can_take_back_ownership` |
+| Hidden owner | -10 | GoPlus `hidden_owner` |
+| External calls | -5 | GoPlus `external_call` |
+| Source not verified | -20 | GoPlus `is_open_source == "0"` |
+| Buy/sell tax > 5% | -5 each | GoPlus `buy_tax`, `sell_tax` |
+
+**Score = max(0, 100 - sum(deductions))**
+
+**Tiers:**
+- 80-100: **TRUSTED** — minimal mutation risk
+- 50-79: **MODERATE** — some upgradeable/admin capabilities
+- 20-49: **RISKY** — significant mutation potential
+- 0-19: **DANGEROUS** — high probability of malicious mutation
+
+---
+
+## Recipes
+
+### Recipe 1: Quick Mutation Check
+
+```
+Check if {contract_address} on {chain} is upgradeable and what risks it has:
+1. Call Etherscan getsourcecode → check Proxy field
+2. If proxy: fetch implementation ABI, scan for dangerous functions
+3. Call GoPlus → get runtime safety flags
+4. Calculate Trust Decay Score
+5. Report: "This contract is [upgradeable/immutable]. Trust Score: XX/100. Risks: [list]"
+```
+
+### Recipe 2: Implementation Comparison
+
+```
+Compare proxy contract's current vs previous implementation:
+1. Fetch proxy's getsourcecode → get current Implementation address
+2. Fetch Implementation's ABI
+3. Scan for dangerous functions added in the implementation
+4. If user provides a previous implementation address, diff the ABIs
+5. Report: "New functions added: mint(), setTax(). Removed: none. Risk increased by X points."
+```
+
+### Recipe 3: Contract Safety Report
+
+```
+Generate a comprehensive safety report for {contract_address}:
+1. Etherscan: source code, proxy status, implementation
+2. GoPlus: all 20+ security flags
+3. ABI scan: dangerous function detection
+4. Trust Decay Score calculation
+5. Output: Score, proxy status, dangerous functions list, GoPlus flags, owner info
+```
+
+### Recipe 4: Batch Contract Screening
+
+```
+Screen multiple contracts at once:
+1. Accept comma-separated addresses
+2. For each: call GoPlus (supports batch via comma-separated addresses)
+3. For proxies: fetch Etherscan implementation details
+4. Rank by Trust Decay Score (lowest = most risky)
+5. Output sorted table: Address | Name | Proxy? | Score | Top Risk
+```
+
+---
+
+## Rate Limits
+
+| API | Limit |
+|-----|-------|
+| Etherscan V2 (free) | 3 calls/sec, 100K calls/day |
+| GoPlus | ~30 req/min, no auth required |
+
+## Notes
+
+- Etherscan API key: free at [etherscan.io](https://etherscan.io) — one key works for all 60+ chains
+- `getsourcecode` and `getabi` are FREE on all chains including BSC (verified contract endpoints)
+- `getcontractcreation` and `txlistinternal` require paid plan for BSC
+- GoPlus is fully free, no registration needed
+- All GoPlus boolean fields use `"0"`/`"1"` strings, not true/false
+- When scanning ABI, `result` from Etherscan is a JSON string — needs `JSON.parse()`
+- For unverified proxy contracts, read EIP-1967 implementation slot directly:
+  `eth_getStorageAt(address, "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc")`
+- A token can pass GoPlus audit today and fail tomorrow if the proxy gets upgraded — this is the gap this skill fills

--- a/skills/binance-web3/liquidity-lifecycle/SKILL.md
+++ b/skills/binance-web3/liquidity-lifecycle/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: liquidity-lifecycle
+description: |
+  Track the complete liquidity lifecycle of any token — from LP creation to lock status,
+  holder concentration, DEX distribution, and rug probability estimation.
+  Combines GoPlus Security API (LP holders, lock status, DEX pairs) with DexScreener
+  (real-time liquidity, volume, pair data) to build a comprehensive liquidity health profile.
+metadata:
+  author: mefai-dev
+  version: "1.0"
+---
+
+# Liquidity Lifecycle Tracker
+
+## Overview
+
+| Source | Data | Free |
+|--------|------|------|
+| GoPlus Security API | LP holders, lock status, DEX list, holder concentration | Yes |
+| DexScreener API | Real-time liquidity, volume, pair age, transactions | Yes |
+
+## Use Cases
+
+1. **Rug Pull Detection** — Check if LP is locked, who holds the most LP tokens, and whether large LP withdrawals have occurred
+2. **Liquidity Health Score** — Combine lock status, holder distribution, and DEX depth into a single 0-100 score
+3. **LP Holder Tracking** — Monitor top LP holders: are they contracts (lock/farm) or EOAs (potential dumpers)?
+4. **Multi-DEX Distribution** — See all DEX pairs, their liquidity depth, and which DEX dominates
+5. **New Token Due Diligence** — Before buying, check liquidity age, lock status, and concentration
+
+## Supported Chains
+
+| Chain | GoPlus chainId | DexScreener chainId |
+|-------|---------------|---------------------|
+| BSC | `56` | `bsc` |
+| Ethereum | `1` | `ethereum` |
+| Solana | `solana` | `solana` |
+| Base | `8453` | `base` |
+| Arbitrum | `42161` | `arbitrum` |
+| Polygon | `137` | `polygon` |
+| Avalanche | `43114` | `avalanche` |
+
+---
+
+## API 1: GoPlus Token Security — LP Data
+
+Returns LP holder list, lock status, DEX pairs, and holder concentration for any token.
+
+### Request
+
+```
+GET https://api.gopluslabs.io/api/v1/token_security/{chainId}?contract_addresses={address}
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `chainId` | string | Yes | Chain ID (e.g., `56` for BSC) |
+| `contract_addresses` | string | Yes | Token contract address |
+
+### Example Request
+
+```bash
+curl "https://api.gopluslabs.io/api/v1/token_security/56?contract_addresses=0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82"
+```
+
+### Response — LP-Related Fields
+
+```json
+{
+  "code": 1,
+  "message": "OK",
+  "result": {
+    "0x0e09...": {
+      "lp_holder_count": "50322",
+      "lp_total_supply": "209476.69027798463699495",
+      "is_in_dex": "1",
+      "lp_holders": [
+        {
+          "address": "0xa5f8c5dbd5f286960b9d90548680ae5ebff07652",
+          "is_contract": 1,
+          "balance": "110192.99",
+          "percent": "0.526012",
+          "is_locked": 0,
+          "tag": ""
+        }
+      ],
+      "dex": [
+        {
+          "name": "PancakeV2",
+          "liquidity_type": "UniV2",
+          "liquidity": "7351206.82",
+          "pair": "0x0ed7e52944161450477ee417de9cd3a859b14fd0"
+        }
+      ],
+      "holder_count": "1896226",
+      "holders": [
+        {
+          "address": "0x000...dead",
+          "is_contract": 0,
+          "balance": "3325273714",
+          "percent": "0.904899",
+          "is_locked": 1
+        }
+      ]
+    }
+  }
+}
+```
+
+### LP Holder Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `address` | string | LP holder wallet/contract address |
+| `is_contract` | int | `1` = contract (farm/lock/router), `0` = EOA (wallet) |
+| `balance` | string | LP token balance held |
+| `percent` | string | Fraction of total LP supply (0-1) |
+| `is_locked` | int | `1` = tokens locked in lock contract, `0` = unlocked |
+| `tag` | string | Label if known (e.g., "PancakeSwap") |
+
+### DEX Pair Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | DEX name (PancakeV2, UniswapV3, etc.) |
+| `liquidity_type` | string | AMM type: `UniV2`, `UniV3`, `UniV4` |
+| `liquidity` | string | USD liquidity value |
+| `pair` | string | Pair contract address |
+
+### Other Useful Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `lp_holder_count` | string | Total number of LP holders |
+| `lp_total_supply` | string | Total LP token supply |
+| `is_in_dex` | string | `"1"` = listed on DEX |
+| `holder_count` | string | Total token holders |
+| `is_proxy` | string | `"1"` = upgradeable proxy contract |
+| `owner_address` | string | Contract owner |
+| `is_honeypot` | string | `"1"` = honeypot detected |
+| `buy_tax` | string | Buy tax (0-1 scale) |
+| `sell_tax` | string | Sell tax (0-1 scale) |
+
+---
+
+## API 2: DexScreener Token — Real-Time Liquidity
+
+Returns all trading pairs for a token with real-time liquidity, volume, and transaction data.
+
+### Request
+
+```
+GET https://api.dexscreener.com/tokens/v1/{chainId}/{address}
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `chainId` | string | Yes | Chain slug (`bsc`, `ethereum`, `solana`) |
+| `address` | string | Yes | Token contract address |
+
+### Example Request
+
+```bash
+curl "https://api.dexscreener.com/tokens/v1/bsc/0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82"
+```
+
+### Response Fields (per pair)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pairAddress` | string | DEX pair contract address |
+| `baseToken.symbol` | string | Token symbol |
+| `baseToken.name` | string | Token name |
+| `priceUsd` | string | Current price in USD |
+| `liquidity.usd` | number | Total liquidity in USD |
+| `liquidity.base` | number | Base token liquidity |
+| `liquidity.quote` | number | Quote token liquidity |
+| `volume.h24` | number | 24h volume |
+| `volume.h1` | number | 1h volume |
+| `txns.h24.buys` | number | 24h buy transactions |
+| `txns.h24.sells` | number | 24h sell transactions |
+| `priceChange.h24` | number | 24h price change % |
+| `pairCreatedAt` | number | Pair creation timestamp (ms) |
+| `fdv` | number | Fully diluted valuation |
+| `marketCap` | number | Market cap |
+
+---
+
+## Liquidity Health Score Algorithm
+
+Combine GoPlus + DexScreener data into a 0-100 score:
+
+| Factor | Points | Condition |
+|--------|--------|-----------|
+| LP Locked | 0-30 | `sum(locked_lp_percent)` × 30 |
+| LP Concentration | 0-20 | Top holder < 50% = 20, < 80% = 10, else 0 |
+| Liquidity Depth | 0-20 | > $100K = 20, > $10K = 10, > $1K = 5, else 0 |
+| Pair Age | 0-15 | > 30d = 15, > 7d = 10, > 1d = 5, else 0 |
+| Holder Count | 0-15 | > 1000 = 15, > 100 = 10, > 10 = 5, else 0 |
+
+**Score tiers:**
+- 80-100: **SAFE** (green) — locked LP, distributed holders, deep liquidity
+- 50-79: **CAUTION** (yellow) — partial lock or moderate concentration
+- 0-49: **DANGER** (red) — unlocked LP, high concentration, shallow liquidity
+
+---
+
+## Recipes
+
+### Recipe 1: Quick Liquidity Check
+
+```
+Check if {token_address} on {chain} has locked liquidity:
+1. Call GoPlus API with the token address
+2. Sum is_locked LP holder percentages
+3. If total locked > 80% → "LP is well locked"
+4. If total locked < 20% → "WARNING: Most LP is unlocked"
+5. Show top 5 LP holders with lock status
+```
+
+### Recipe 2: Full Liquidity Report
+
+```
+Generate a complete liquidity report for {token_address}:
+1. Fetch GoPlus data (LP holders, DEX list, holder info)
+2. Fetch DexScreener data (real-time liquidity, volume, pair age)
+3. Calculate Liquidity Health Score
+4. Show: Score, Lock %, Top LP Holders, DEX Distribution, Pair Age, Volume/Liquidity ratio
+5. Flag any red flags (unlocked LP > 50%, single holder > 80%, no lock contract)
+```
+
+### Recipe 3: Rug Risk Assessment
+
+```
+Assess rug pull risk for {token_address}:
+1. Check LP lock status (GoPlus lp_holders.is_locked)
+2. Check if owner can modify (owner_change_balance, can_take_back_ownership)
+3. Check honeypot status (is_honeypot)
+4. Check tax levels (buy_tax, sell_tax > 10% = warning)
+5. Check holder concentration (top holder > 50% = warning)
+6. Calculate composite rug risk score
+```
+
+---
+
+## Notes
+
+- GoPlus API is free, no authentication required, rate limit ~30 req/min
+- DexScreener API is free, no authentication, rate limit 300 req/min
+- All GoPlus numeric fields are strings — convert with `parseFloat()`
+- `is_locked` in GoPlus only indicates if the LP tokens are held by a known lock contract
+- For detailed lock expiry times, cross-reference with lock platforms (Team.Finance, Unicrypt)
+- The `dex` array can contain 50+ pairs for popular tokens — aggregate by DEX name for overview

--- a/skills/binance/dca-backtester/SKILL.md
+++ b/skills/binance/dca-backtester/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: dca-backtester
+description: Dollar-cost averaging backtester that simulates DCA strategies over historical Binance data, comparing daily, weekly, and monthly accumulation versus lump-sum investing with ROI, drawdown, and cost-basis analysis.
+metadata:
+  version: 1.0.0
+  author: mefai-dev
+  display_name: DCA Backtester
+license: MIT
+---
+
+# DCA Backtester
+
+Interactive backtesting tool that simulates dollar-cost averaging strategies using historical Binance kline data. Users select a pair, DCA frequency (daily/weekly/monthly), investment amount per period, and backtest window (30-365 days). Shows total invested, portfolio value, ROI, average cost basis, max drawdown, and side-by-side comparison with a lump-sum entry at the start of the period.
+
+## Quick Reference
+
+| Endpoint | Description | Required | Optional | Authentication |
+|----------|-------------|----------|----------|----------------|
+| `/api/v3/klines` (GET) | Kline/Candlestick data | symbol, interval | startTime, endTime, limit | No |
+
+## Parameters
+
+* **symbol**: Trading pair (e.g., BTCUSDT)
+* **interval**: `1d` for daily close prices
+* **limit**: Up to `1000` candles (covers ~2.7 years of daily data)
+
+## Supported Pairs
+
+BTCUSDT, ETHUSDT, BNBUSDT, SOLUSDT, XRPUSDT, DOGEUSDT, ADAUSDT, AVAXUSDT, LINKUSDT, SUIUSDT, APTUSDT, ARBUSDT, OPUSDT, NEARUSDT, LTCUSDT
+
+## User Inputs
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| Symbol | Trading pair dropdown | BTCUSDT |
+| Amount | Investment per period (USDT) | 100 |
+| Frequency | Daily / Weekly / Monthly | Weekly |
+| Period | Backtest window in days: 30, 90, 180, 365 | 90 |
+
+## How It Works
+
+1. User selects pair, amount per period, frequency, and backtest window
+2. Fetches daily klines via `/api/v3/klines` for the selected period
+3. **DCA Simulation**: At each DCA interval (daily/weekly/monthly), calculates how many units purchased at that day's close price
+4. Accumulates: total units acquired, total USDT invested, running cost basis
+5. **Lump-Sum Comparison**: Calculates result of investing the same total amount on day 1
+6. **Current Value**: `total_units * current_price`
+7. **ROI**: `(current_value - total_invested) / total_invested * 100`
+8. **Average Cost Basis**: `total_invested / total_units`
+9. **Max Drawdown**: Largest peak-to-trough decline in portfolio value during the period
+10. Visual chart showing DCA portfolio value curve vs lump-sum curve over time
+
+## Output
+
+| Output | Description |
+|--------|-------------|
+| Summary | "Investing $100/week in BTC over 90 days: $1,300 invested → $1,487 value (14.4% ROI)" |
+| DCA Stats Card | Total invested, current value, ROI %, avg cost basis, total units acquired |
+| Lump-Sum Card | Same metrics for lump-sum comparison |
+| Winner Badge | Which strategy performed better and by how much |
+| Drawdown | Maximum drawdown percentage during the period |
+| Visual Chart | Portfolio value over time: DCA line vs lump-sum line |
+| Buy Points | Each DCA purchase marked on the price chart (date, price, units bought) |
+
+## DCA vs Lump-Sum Analysis
+
+| Metric | DCA | Lump-Sum |
+|--------|-----|----------|
+| Entry | Spread across N periods | Single entry at start |
+| Risk | Lower — averages out volatility | Higher — fully exposed to timing |
+| Uptrend | Typically underperforms lump-sum | Captures full upside from day 1 |
+| Downtrend | Outperforms — buys more at lower prices | Full drawdown exposure |
+| Sideways/Volatile | Often outperforms — benefits from volatility | No averaging benefit |
+
+## Refresh
+
+Button-triggered only (no auto-refresh). Each simulation fetches fresh historical data.
+
+## Use Cases
+
+- Backtest DCA strategies before committing real capital
+- Compare dollar-cost averaging vs timing the market with historical evidence
+- Understand how frequency (daily vs weekly vs monthly) affects outcomes
+- Educational tool showing the power of consistent accumulation in volatile markets
+- Evaluate which pairs benefited most from DCA over different time horizons
+- Pre-planning tool for Binance Auto-Invest configuration

--- a/skills/binance/dca-backtester/SKILL.md
+++ b/skills/binance/dca-backtester/SKILL.md
@@ -1,10 +1,9 @@
 ---
-name: dca-backtester
+title: DCA Backtester
 description: Dollar-cost averaging backtester that simulates DCA strategies over historical Binance data, comparing daily, weekly, and monthly accumulation versus lump-sum investing with ROI, drawdown, and cost-basis analysis.
 metadata:
-  version: 1.0.0
+  version: "1.0.0"
   author: mefai-dev
-  display_name: DCA Backtester
 license: MIT
 ---
 


### PR DESCRIPTION
## Summary

Interactive dollar-cost averaging backtester using historical Binance kline data.

- Simulates DCA (daily/weekly/monthly) over 30-365 days of real price history
- Side-by-side comparison with lump-sum entry showing which strategy won
- Shows ROI, average cost basis, max drawdown, and portfolio value curves

## Endpoint Used

| Endpoint | Description |
|----------|-------------|
| `/api/v3/klines` (GET) | Daily close prices for historical simulation |

## How It Works

1. User selects pair, amount per period, frequency, and backtest window
2. Fetches up to 1000 daily candles via `/api/v3/klines`
3. Simulates purchases at each DCA interval using close prices
4. Calculates total invested, current value, ROI, cost basis
5. Compares with lump-sum entry on day 1 of the same period

## Use Cases

- Backtest DCA strategies before committing capital
- Compare dollar-cost averaging vs market timing with evidence
- Pre-planning tool for Binance Auto-Invest configuration
- Educational: demonstrates the power of consistent accumulation