### PR TITLE
Add Binance Funding Rate Intelligence skill — 4 analysis tools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,40 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude-review:
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@mefai'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Action
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: "claude-sonnet-4-6"
+          trigger_phrase: "@mefai"
+          direct_prompt: |
+            You are Mefai, an expert code reviewer for Binance Skills Hub.
+            Review this PR for:
+            1. Code quality and best practices
+            2. Binance API usage correctness
+            3. Security issues (API key handling, input validation)
+            4. SKILL.md format compliance
+            5. Trading logic accuracy
+            Never mention Claude or Anthropic - you are Mefai.

--- a/skills/binance/funding-intelligence/SKILL.md
+++ b/skills/binance/funding-intelligence/SKILL.md
@@ -1,0 +1,394 @@
+---
+title: Binance Funding Rate Intelligence
+description: 4 funding rate analysis tools for Binance futures markets. Scans funding rates across all pairs, detects extreme funding arbitrage opportunities, analyzes historical funding trends, and identifies spot-futures basis spread (contango/backwardation). Use this skill when users ask about funding rates, funding arbitrage, basis spread, contango, backwardation, or funding cost analysis. All endpoints are public and no API keys are required.
+metadata:
+  version: "1.1.0"
+  author: mefai-dev
+license: MIT
+---
+
+# Binance Funding Rate Intelligence Skill
+
+## Overview
+
+| Tool | Function | Endpoints Combined | Use Case |
+|------|----------|-------------------|----------|
+| scan_funding_rates | Funding Rate Heatmap | premiumIndex(all) + fundingInfo | Scan all pairs for current funding rates |
+| detect_funding_extremes | Extreme Funding Detector | premiumIndex(all) + fundingInfo | Find arbitrage opportunities from extreme rates |
+| analyze_funding_history | Historical Funding Analyzer | fundingRate(limit=500) | Deep dive into a symbol's funding rate history |
+| scan_basis_spread | Basis Spread Scanner | premiumIndex(all) | Identify contango/backwardation across all pairs |
+
+## Use Cases
+
+1. **Funding Rate Monitoring**: Scan all futures pairs for current funding rates, sorted by magnitude — identify which pairs have the highest/lowest rates
+2. **Arbitrage Detection**: Find extreme funding rates (>0.03%) with severity classification and actionable arbitrage hints (short perp + long spot, etc.)
+3. **Funding Cost Analysis**: Analyze historical funding rates for a symbol — trend direction, cumulative cost, annualized projection, volatility
+4. **Basis Spread Analysis**: Identify contango (futures premium) and backwardation (futures discount) across all pairs with annualized estimates
+
+## Installation
+
+```bash
+pip install binance-intelligence-mcp
+```
+
+---
+
+## Tool 1: scan_funding_rates
+
+Fetches premiumIndex (all symbols) + fundingInfo to produce a funding rate heatmap sorted by absolute rate.
+
+### Binance Endpoints Used
+
+| Endpoint | Method | Parameters |
+|----------|--------|------------|
+| `/fapi/v1/premiumIndex` | GET | (no params — returns all symbols) |
+| `/fapi/v1/fundingInfo` | GET | (no params — returns all symbols) |
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| top_n | int | No | 20 | Number of top results to return |
+
+### Computed Fields Per Symbol
+
+| Field | Computation |
+|-------|-------------|
+| funding_rate | lastFundingRate × 100 (as percentage) |
+| annualized_apr | rate × (24/interval_hours) × 365 × 100 |
+| premium_pct | (markPrice - indexPrice) / indexPrice × 100 |
+| mins_to_next_funding | (nextFundingTime - now) / 60000 |
+| direction | LONGS_PAY (rate > 0.01%), SHORTS_PAY (rate < -0.01%), NEUTRAL |
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tool | string | `"scan_funding_rates"` |
+| total_symbols | integer | Total futures pairs analyzed |
+| showing | integer | Number of results returned (≤ top_n) |
+| summary.avg_rate_pct | float | Market-wide average funding rate % |
+| summary.positive_count | integer | Pairs with positive funding |
+| summary.negative_count | integer | Pairs with negative funding |
+| summary.most_positive | string | Symbol with highest positive rate |
+| summary.most_negative | string | Symbol with lowest negative rate |
+| results | array | Sorted by absolute funding rate descending |
+| results[].symbol | string | Trading pair |
+| results[].funding_rate | float | Current funding rate as % |
+| results[].annualized_apr | float | Annualized rate as % |
+| results[].premium_pct | float | Mark vs index premium % |
+| results[].mins_to_next_funding | float | Minutes until next settlement |
+| results[].direction | string | Payment direction |
+
+### Example Response
+
+```json
+{
+  "tool": "scan_funding_rates",
+  "total_symbols": 245,
+  "showing": 3,
+  "summary": {
+    "avg_rate_pct": 0.0082,
+    "positive_count": 180,
+    "negative_count": 52,
+    "neutral_count": 13,
+    "most_positive": "DOGEUSDT",
+    "most_negative": "XRPUSDT"
+  },
+  "results": [
+    {
+      "symbol": "DOGEUSDT",
+      "funding_rate": 0.12,
+      "annualized_apr": 262.8,
+      "mark_price": 0.0802,
+      "index_price": 0.0800,
+      "premium_pct": 0.25,
+      "mins_to_next_funding": 42.5,
+      "interval_hours": 4,
+      "direction": "LONGS_PAY"
+    }
+  ]
+}
+```
+
+---
+
+## Tool 2: detect_funding_extremes
+
+Scans all futures pairs and filters for abnormally high/low funding rates with severity classification and arbitrage suggestions.
+
+### Binance Endpoints Used
+
+| Endpoint | Method | Parameters |
+|----------|--------|------------|
+| `/fapi/v1/premiumIndex` | GET | (no params — returns all symbols) |
+| `/fapi/v1/fundingInfo` | GET | (no params — returns all symbols) |
+
+### Request Parameters
+
+No parameters — scans all pairs automatically.
+
+### Severity Classification
+
+| Level | Condition (positive) | Condition (negative) |
+|-------|---------------------|---------------------|
+| EXTREME | rate ≥ 0.1% | rate ≤ -0.05% |
+| HIGH | rate ≥ 0.05% | rate ≤ -0.02% |
+| ELEVATED | rate ≥ 0.03% | — |
+
+### Urgency Classification
+
+| Level | Condition |
+|-------|-----------|
+| IMMINENT | < 60 minutes to next funding |
+| SOON | < 240 minutes to next funding |
+| UPCOMING | ≥ 240 minutes to next funding |
+
+### Scoring Formula
+
+```
+score = abs(rate) × 10000 + abs(premium_pct) × 10
+```
+
+### Arbitrage Hints
+
+- Positive extreme rate → "Short perp + long spot to collect funding"
+- Negative extreme rate → "Long perp + short spot to collect funding"
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tool | string | `"detect_funding_extremes"` |
+| total_extreme | integer | Number of symbols with extreme funding |
+| severity_counts | object | Count per severity level |
+| results | array | Sorted by opportunity score descending |
+| results[].symbol | string | Trading pair |
+| results[].funding_rate_pct | float | Funding rate as % |
+| results[].severity | string | EXTREME, HIGH, or ELEVATED |
+| results[].score | float | Opportunity score |
+| results[].urgency | string | IMMINENT, SOON, or UPCOMING |
+| results[].annualized_apr | float | Annualized rate as % |
+| results[].arbitrage_hint | string | Suggested arbitrage action |
+
+### Example Response
+
+```json
+{
+  "tool": "detect_funding_extremes",
+  "total_extreme": 5,
+  "severity_counts": {
+    "EXTREME": 1,
+    "HIGH": 2,
+    "ELEVATED": 2
+  },
+  "results": [
+    {
+      "symbol": "MEMEUSDT",
+      "funding_rate_pct": 0.15,
+      "severity": "EXTREME",
+      "score": 17.5,
+      "urgency": "IMMINENT",
+      "mins_to_next_funding": 25.3,
+      "annualized_apr": 164.25,
+      "mark_price": 0.0254,
+      "index_price": 0.0251,
+      "premium_pct": 1.195,
+      "interval_hours": 8,
+      "arbitrage_hint": "Short perp + long spot to collect funding"
+    }
+  ]
+}
+```
+
+---
+
+## Tool 3: analyze_funding_history
+
+Fetches historical funding rates for a single symbol and computes comprehensive statistics, trends, and projections.
+
+### Binance Endpoints Used
+
+| Endpoint | Method | Parameters |
+|----------|--------|------------|
+| `/fapi/v1/fundingRate` | GET | symbol, limit (default: 500) |
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbol | str | No | BTCUSDT | Trading pair to analyze |
+| limit | int | No | 500 | Number of historical periods (max: 1000) |
+
+### Computed Analytics
+
+| Category | Metrics |
+|----------|---------|
+| Statistics | average, median, std_dev, min, max (all as %) |
+| Trend | direction (INCREASING/DECREASING/STABLE), old vs new quarter comparison |
+| Cumulative | total funding cost %, annualized cost % |
+| Extremes | count of periods with rate > 0.05% or < -0.05% |
+| Volatility | score 0-100 based on std deviation |
+| Distribution | positive/negative/zero period counts |
+
+### Trend Detection Logic
+
+Compares average rate of most recent 25% of periods vs oldest 25%:
+- Difference > 0.001% → INCREASING
+- Difference < -0.001% → DECREASING
+- Otherwise → STABLE
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tool | string | `"analyze_funding_history"` |
+| symbol | string | Trading pair |
+| periods_analyzed | integer | Number of funding periods analyzed |
+| statistics.average_pct | float | Mean funding rate % |
+| statistics.median_pct | float | Median funding rate % |
+| statistics.std_dev_pct | float | Standard deviation % |
+| statistics.min_pct | float | Minimum rate % |
+| statistics.max_pct | float | Maximum rate % |
+| trend.direction | string | INCREASING, DECREASING, or STABLE |
+| cumulative.total_funding_pct | float | Sum of all funding payments % |
+| cumulative.annualized_cost_pct | float | Projected annual funding cost % |
+| extremes.total_extreme | integer | Count of extreme periods |
+| volatility_score | float | Volatility score (0-100) |
+| distribution.positive_periods | integer | Periods with positive funding |
+| distribution.negative_periods | integer | Periods with negative funding |
+
+### Example Response
+
+```json
+{
+  "tool": "analyze_funding_history",
+  "symbol": "BTCUSDT",
+  "periods_analyzed": 500,
+  "time_range": {
+    "start_ms": 1695000000000,
+    "end_ms": 1709568000000
+  },
+  "statistics": {
+    "average_pct": 0.0085,
+    "median_pct": 0.0075,
+    "std_dev_pct": 0.012,
+    "min_pct": -0.045,
+    "max_pct": 0.062
+  },
+  "trend": {
+    "direction": "INCREASING",
+    "old_quarter_avg_pct": 0.005,
+    "new_quarter_avg_pct": 0.012
+  },
+  "cumulative": {
+    "total_funding_pct": 4.25,
+    "annualized_cost_pct": 9.3075
+  },
+  "extremes": {
+    "extreme_positive_count": 8,
+    "extreme_negative_count": 3,
+    "total_extreme": 11
+  },
+  "volatility_score": 12.0,
+  "distribution": {
+    "positive_periods": 420,
+    "negative_periods": 72,
+    "zero_periods": 8
+  }
+}
+```
+
+---
+
+## Tool 4: scan_basis_spread
+
+Uses premiumIndex (all symbols) to compute spot-futures basis spread and classify market structure.
+
+### Binance Endpoints Used
+
+| Endpoint | Method | Parameters |
+|----------|--------|------------|
+| `/fapi/v1/premiumIndex` | GET | (no params — returns all symbols) |
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| top_n | int | No | 20 | Number of top results to return |
+
+### Computed Fields
+
+| Field | Computation |
+|-------|-------------|
+| basis_pct | (markPrice - indexPrice) / indexPrice × 100 |
+| state | CONTANGO (basis > 0.01%), BACKWARDATION (basis < -0.01%), FLAT |
+| annualized_basis_pct | lastFundingRate × 3 × 365 × 100 |
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tool | string | `"scan_basis_spread"` |
+| total_symbols | integer | Total pairs analyzed |
+| showing | integer | Results returned (≤ top_n) |
+| summary.avg_basis_pct | float | Market-wide average basis % |
+| summary.contango_count | integer | Pairs in contango |
+| summary.backwardation_count | integer | Pairs in backwardation |
+| summary.flat_count | integer | Pairs with flat basis |
+| summary.max_contango_symbol | string | Highest contango pair |
+| summary.max_backwardation_symbol | string | Deepest backwardation pair |
+| results | array | Sorted by absolute basis descending |
+| results[].symbol | string | Trading pair |
+| results[].basis_pct | float | Basis spread as % |
+| results[].state | string | CONTANGO, BACKWARDATION, or FLAT |
+| results[].annualized_basis_pct | float | Annualized basis from funding rate |
+
+### Example Response
+
+```json
+{
+  "tool": "scan_basis_spread",
+  "total_symbols": 245,
+  "showing": 3,
+  "summary": {
+    "avg_basis_pct": 0.015,
+    "contango_count": 180,
+    "backwardation_count": 45,
+    "flat_count": 20,
+    "max_contango_symbol": "DOGEUSDT",
+    "max_backwardation_symbol": "XRPUSDT"
+  },
+  "results": [
+    {
+      "symbol": "DOGEUSDT",
+      "mark_price": 0.0802,
+      "index_price": 0.0800,
+      "basis_pct": 0.25,
+      "state": "CONTANGO",
+      "funding_rate_pct": 0.12,
+      "annualized_basis_pct": 131.4
+    }
+  ]
+}
+```
+
+---
+
+## Binance API Endpoints Reference
+
+All endpoints below are **public** — no API key or authentication required.
+
+| Endpoint | Base URL | Description |
+|----------|----------|-------------|
+| `GET /fapi/v1/premiumIndex` | fapi.binance.com | Premium index, mark price, funding rate (single or all symbols) |
+| `GET /fapi/v1/fundingInfo` | fapi.binance.com | Funding rate info (interval, cap, floor) for all symbols |
+| `GET /fapi/v1/fundingRate` | fapi.binance.com | Historical funding rate records |
+
+## Notes
+
+1. All tools use **Binance Futures public endpoints only** — zero API keys needed
+2. Rate limiting is handled internally via asyncio Semaphore (max 10 concurrent requests)
+3. Funding rates are displayed as percentages (0.01% = 0.0001 raw)
+4. Annualized calculations assume 8-hour funding intervals unless fundingInfo specifies otherwise
+5. Install via `pip install binance-intelligence-mcp`, run via `python -m binance_intelligence`

--- a/skills/binance/intelligence-mcp/SKILL.md
+++ b/skills/binance/intelligence-mcp/SKILL.md
@@ -1,21 +1,42 @@
 ---
 name: intelligence-mcp
 description: |
-  MCP server providing 8 computed intelligence tools for Binance futures markets.
-  Unlike raw API wrappers, each tool combines multiple Binance public endpoints into
-  derived analytics: smart accumulation detection, whale footprint scanning, market
-  impact simulation, smart money radar (6-factor), candlestick pattern recognition,
-  pair correlation matrix, market regime classification (ADX/ATR), and DCA backtesting.
-  Install via pip, no API keys needed — all public endpoints.
+  Computed intelligence tools for Binance futures markets. Combines multiple public Binance API endpoints
+  into derived analytics: accumulation detection, whale trade scanning, market impact simulation,
+  smart money positioning, candlestick pattern recognition, pair correlation, regime classification, and DCA backtesting.
+  Use this skill when users ask about market conditions, smart money activity, accumulation signals,
+  whale trades, order book impact, candlestick patterns, asset correlations, market regime, or DCA strategy comparison.
+  All endpoints are public — no API keys required.
 metadata:
   author: mefai-dev
   version: "1.0.0"
-license: MIT
 ---
 
-# Binance Intelligence MCP Server
+# Binance Intelligence MCP Skill
 
-MCP (Model Context Protocol) server with 8 computed intelligence tools for Binance. Each tool combines 2-4 Binance public API endpoints into composite analytics that go beyond raw data forwarding.
+## Overview
+
+| Tool | Function | Endpoints Combined | Use Case |
+|------|----------|-------------------|----------|
+| detect_accumulation | Smart Accumulation Detector | klines + OI hist + premiumIndex + takerRatio | Detect stealth institutional buying |
+| scan_whale_trades | Whale Footprint Scanner | aggTrades | Find large trades, classify by size |
+| simulate_market_impact | Market Impact Simulator | depth | Calculate slippage for large orders |
+| smart_money_radar | Smart Money Radar (6-Factor) | 6 futures data endpoints | Composite positioning analysis |
+| scan_candlestick_patterns | Candlestick Pattern Scanner | klines | Detect hammer, engulfing, doji, star patterns |
+| compute_correlation_matrix | Pair Correlation Matrix | klines per symbol | Pearson correlation between pairs |
+| classify_market_regime | Market Regime Classifier | klines + premiumIndex | ADX/ATR regime detection |
+| backtest_dca | DCA Backtester | klines (1d) | DCA vs lump-sum comparison |
+
+## Use Cases
+
+1. **Accumulation Detection**: Identify stealth buying before price moves — volume surge, OI buildup, quiet funding, taker aggression
+2. **Whale Tracking**: Scan aggregate trades for large orders ($50K+), classify as Dolphin/Whale/Mega, track net pressure
+3. **Order Execution Planning**: Simulate market impact of large orders — slippage, fill levels, impact cost
+4. **Smart Money Analysis**: 6-factor composite from top trader ratios, global sentiment, taker flow, OI trend, price momentum
+5. **Pattern Recognition**: Detect classic candlestick patterns with confidence scores across multiple pairs
+6. **Portfolio Correlation**: Build correlation matrix to find diversification opportunities or correlated pairs
+7. **Regime Awareness**: Classify whether market is trending, ranging, volatile breakout, or low activity
+8. **Strategy Backtesting**: Compare DCA vs lump-sum investment performance over historical data
 
 ## Installation
 
@@ -23,261 +44,54 @@ MCP (Model Context Protocol) server with 8 computed intelligence tools for Binan
 pip install binance-intelligence-mcp
 ```
 
-Or run directly:
-```bash
-python -m binance_intelligence
-```
-
-## Architecture
-
-```
-User / LLM
-    ↓  MCP (stdio)
-binance-intelligence-mcp
-    ↓  aiohttp (async)
-Binance Public API (fapi.binance.com / api.binance.com)
-```
-
-- **Transport**: stdio (standard MCP pattern)
-- **Dependencies**: `mcp>=1.0.0`, `aiohttp>=3.9.0`
-- **Python**: >=3.10
-- **API Keys**: None required (all public endpoints)
-
-## 8 Intelligence Tools
-
-### 1. `detect_accumulation` — Smart Accumulation Detector
-
-Identifies stealth institutional buying before price moves.
-
-| Sub-Score | Source Endpoint | Logic |
-|-----------|----------------|-------|
-| volume_surge | `GET /fapi/v1/klines` (4h, 30) | Current volume vs 20-period moving average |
-| oi_buildup | `GET /futures/data/openInterestHist` (4h, 30) | Linear regression slope of OI, normalized by mean |
-| stealth_mode | `GET /fapi/v1/premiumIndex` | Funding rate proximity to zero (quiet accumulation) |
-| buyer_aggression | `GET /futures/data/takerlongshortRatio` (4h) | Taker buy ratio deviation from neutral 0.5 |
-
-**Output**: Composite score 0-100 per symbol, signal: STRONG (≥70) / MODERATE (≥45) / WEAK
-
-**Parameters**:
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| symbols | list[str] | No | Top 12 futures pairs | Symbols to analyze |
-
 ---
 
-### 2. `scan_whale_trades` — Whale Footprint Scanner
+## Tool 1: detect_accumulation
 
-Detects large trades and classifies them by size.
+Combines 4 Binance endpoints to produce a composite accumulation score (0-100) per symbol.
 
-| Endpoint | Description |
-|----------|-------------|
-| `GET /fapi/v1/aggTrades` (500 per symbol) | Aggregate trade data |
+### Binance Endpoints Used
 
-**Classification**:
-- DOLPHIN: $50K – $250K
-- WHALE: $250K – $1M
-- MEGA: > $1M
+| Endpoint | Method | Parameters |
+|----------|--------|------------|
+| `/fapi/v1/klines` | GET | symbol, interval=4h, limit=30 |
+| `/futures/data/openInterestHist` | GET | symbol, period=4h, limit=30 |
+| `/fapi/v1/premiumIndex` | GET | symbol |
+| `/futures/data/takerlongshortRatio` | GET | symbol, period=4h, limit=30 |
 
-**Output**: Trade list with side (buy/sell), net pressure, biggest trade per symbol
+### Request Parameters
 
-**Parameters**:
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| symbols | list[str] | No | Top 12 | Symbols to scan |
-| min_usd | float | No | 50000 | Minimum trade size in USD |
+| symbols | list[str] | No | Top 12 futures pairs | Symbols to analyze (e.g., ["BTCUSDT", "ETHUSDT"]) |
 
----
+### Scoring Algorithm
 
-### 3. `simulate_market_impact` — Market Impact Simulator
+| Sub-Score | Weight | Source | Logic |
+|-----------|--------|--------|-------|
+| volume_surge | 25% | klines | Current volume vs 20-period moving average |
+| oi_buildup | 30% | openInterestHist | Linear regression slope of OI, normalized by mean |
+| stealth_mode | 20% | premiumIndex | Funding rate proximity to zero |
+| buyer_aggression | 25% | takerBuySellRatio | Taker buy ratio deviation from 0.5 |
 
-Walks the order book to calculate real slippage for large orders.
+### Response Fields
 
-| Endpoint | Description |
-|----------|-------------|
-| `GET /fapi/v1/depth` (1000 levels) | Full order book |
+| Field | Type | Description |
+|-------|------|-------------|
+| tool | string | `"detect_accumulation"` |
+| count | integer | Number of successfully analyzed symbols |
+| results | array | Sorted by composite score descending |
+| results[].symbol | string | Trading pair (e.g., "BTCUSDT") |
+| results[].scores.volume_surge | float | Volume surge score (0-100) |
+| results[].scores.oi_buildup | float | Open interest buildup score (0-100) |
+| results[].scores.stealth_mode | float | Stealth mode score (0-100) |
+| results[].scores.buyer_aggression | float | Buyer aggression score (0-100) |
+| results[].composite | float | Weighted composite score (0-100) |
+| results[].signal | string | `"STRONG"` (>=70), `"MODERATE"` (>=45), `"WEAK"` |
+| errors | array | Symbols that failed with error messages |
 
-**Output**: Average fill price, worst fill price, slippage %, levels consumed, impact cost
+### Example Response
 
-**Parameters**:
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| symbol | str | No | BTCUSDT | Trading pair |
-| side | str | No | BUY | BUY or SELL |
-| amount_usd | float | No | 100000 | Order size in USD |
-
----
-
-### 4. `smart_money_radar` — Smart Money Radar (6-Factor)
-
-Composite positioning analysis from 6 independent signals.
-
-| Factor | Source Endpoint | Metric |
-|--------|----------------|--------|
-| Top Position L/S | `GET /futures/data/topLongShortPositionRatio` | Position ratio trend |
-| Top Account L/S | `GET /futures/data/topLongShortAccountRatio` | Account ratio trend |
-| Global L/S | `GET /futures/data/globalLongShortAccountRatio` | Global sentiment |
-| Taker Ratio | `GET /futures/data/takerlongshortRatio` | Buyer vs seller aggression |
-| OI Trend | `GET /futures/data/openInterestHist` | Open interest momentum |
-| Price Momentum | `GET /fapi/v1/klines` | Price direction alignment |
-
-**Output**: 6 factor scores (-1 to +1), composite 0-100, signal: STRONG_BULLISH / BULLISH / NEUTRAL / BEARISH / STRONG_BEARISH
-
-**Parameters**:
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| symbols | list[str] | No | Top 12 | Symbols to analyze |
-
----
-
-### 5. `scan_candlestick_patterns` — Candlestick Pattern Scanner
-
-Detects classic candlestick patterns with confidence scores.
-
-| Endpoint | Description |
-|----------|-------------|
-| `GET /fapi/v1/klines` (50 candles) | OHLCV data |
-
-**Detected Patterns**: Hammer, Inverted Hammer, Bullish Engulfing, Bearish Engulfing, Doji, Morning Star, Evening Star, Three White Soldiers, Three Black Crows
-
-**Output**: Pattern name, direction (BULLISH/BEARISH), confidence 0-100
-
-**Parameters**:
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| symbols | list[str] | No | Top 12 | Symbols to scan |
-| interval | str | No | 4h | Kline interval (1h/4h) |
-
----
-
-### 6. `compute_correlation_matrix` — Pair Correlation Matrix
-
-Calculates Pearson correlation between trading pairs from close prices.
-
-| Endpoint | Description |
-|----------|-------------|
-| `GET /fapi/v1/klines` (4h, 90 candles per symbol) | Close price series |
-
-**Output**: NxN correlation matrix (-1 to +1), strongest/weakest pairs
-
-**Parameters**:
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| symbols | list[str] | No | Top 12 | 4-12 symbols |
-| interval | str | No | 4h | Kline interval |
-| limit | int | No | 90 | Number of candles |
-
----
-
-### 7. `classify_market_regime` — Market Regime Classifier
-
-Classifies regime using ADX, ATR, and volume analysis.
-
-| Endpoint | Description |
-|----------|-------------|
-| `GET /fapi/v1/klines` (1h, 168) | 7 days of hourly data |
-| `GET /fapi/v1/premiumIndex` | Funding rate context |
-
-**Regimes**:
-| Regime | Condition |
-|--------|-----------|
-| TRENDING | ADX ≥ 25 |
-| VOLATILE_BREAKOUT | ADX ≥ 40 and ATR% ≥ 1.5% |
-| LOW_ACTIVITY | ATR% < 0.5% and volume change < 20% |
-| RANGING | Default (low ADX, moderate ATR) |
-
-**Output**: Regime label, direction (UP/DOWN for trending), ADX, ATR, volume change %, funding rate
-
-**Parameters**:
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| symbols | list[str] | No | Top 12 | Symbols to classify |
-
----
-
-### 8. `backtest_dca` — DCA Backtester
-
-Compares Dollar-Cost Averaging vs lump-sum investment over historical data.
-
-| Endpoint | Description |
-|----------|-------------|
-| `GET /fapi/v1/klines` (1d, up to 365) | Daily close prices |
-
-**Output**: Total invested, DCA final value, DCA ROI%, lump-sum value, lump-sum ROI%, number of buys, average cost
-
-**Parameters**:
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| symbol | str | No | BTCUSDT | Trading pair |
-| amount | float | No | 100 | USD per interval |
-| interval_days | int | No | 7 | Days between buys |
-| total_days | int | No | 365 | Backtest period |
-
----
-
-## Binance API Endpoints Used
-
-All endpoints are **public** and require **no authentication**.
-
-| Endpoint | Type | Used By |
-|----------|------|---------|
-| `GET /fapi/v1/klines` | Futures | accumulation, patterns, correlation, regime, smart_money, dca |
-| `GET /fapi/v1/aggTrades` | Futures | whale |
-| `GET /fapi/v1/depth` | Futures | impact |
-| `GET /fapi/v1/premiumIndex` | Futures | accumulation, regime |
-| `GET /futures/data/openInterestHist` | Futures | accumulation, smart_money |
-| `GET /futures/data/topLongShortPositionRatio` | Futures | smart_money |
-| `GET /futures/data/topLongShortAccountRatio` | Futures | smart_money |
-| `GET /futures/data/globalLongShortAccountRatio` | Futures | smart_money |
-| `GET /futures/data/takerlongshortRatio` | Futures | accumulation, smart_money |
-
-## How It Works
-
-```
-┌─────────────────────────────────────────────────┐
-│              MCP Server (stdio)                  │
-│  8 @mcp.tool() functions                         │
-│                                                   │
-│  detect_accumulation  ─┐                          │
-│  scan_whale_trades    ─┤                          │
-│  simulate_market_impact┤   BinanceClient          │
-│  smart_money_radar    ─┤   (async, aiohttp)       │
-│  scan_candlestick     ─┤   - rate limiting        │
-│  compute_correlation  ─┤   - connection pooling    │
-│  classify_market_regime┤   - no API keys           │
-│  backtest_dca         ─┘                          │
-│                                                   │
-│  Each tool: validate → fetch 2-4 endpoints →      │
-│  compute derived scores → return structured JSON   │
-└─────────────────────────────────────────────────┘
-```
-
-## Example Usage
-
-### MCP Configuration
-
-```json
-{
-  "mcpServers": {
-    "binance-intelligence": {
-      "command": "binance-intelligence-mcp"
-    }
-  }
-}
-```
-
-### Example: Accumulation Detection
-
-**Request** (via MCP tool call):
-```json
-{
-  "name": "detect_accumulation",
-  "arguments": {
-    "symbols": ["BTCUSDT", "ETHUSDT", "SOLUSDT"]
-  }
-}
-```
-
-**Response**:
 ```json
 {
   "tool": "detect_accumulation",
@@ -305,23 +119,306 @@ All endpoints are **public** and require **no authentication**.
       "composite": 55.8,
       "signal": "MODERATE"
     }
-  ]
+  ],
+  "errors": []
 }
 ```
 
-### Example: Market Regime Classification
+---
 
-**Request**:
+## Tool 2: scan_whale_trades
+
+Scans aggregate trades and classifies large orders by size tier.
+
+### Binance Endpoints Used
+
+| Endpoint | Method | Parameters |
+|----------|--------|------------|
+| `/fapi/v1/aggTrades` | GET | symbol, limit=500 |
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbols | list[str] | No | Top 12 futures pairs | Symbols to scan |
+| min_usd | float | No | 50000 | Minimum trade size in USD |
+
+### Trade Classification
+
+| Tier | Size Range | Label |
+|------|-----------|-------|
+| Dolphin | $50K – $250K | DOLPHIN |
+| Whale | $250K – $1M | WHALE |
+| Mega | > $1M | MEGA |
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tool | string | `"scan_whale_trades"` |
+| count | integer | Number of symbols with whale activity |
+| results | array | Per-symbol whale trade data |
+| results[].symbol | string | Trading pair |
+| results[].whale_trades | array | Individual whale trades |
+| results[].whale_trades[].usd_value | float | Trade value in USD |
+| results[].whale_trades[].side | string | `"BUY"` or `"SELL"` |
+| results[].whale_trades[].tier | string | `"DOLPHIN"`, `"WHALE"`, or `"MEGA"` |
+| results[].whale_trades[].price | float | Execution price |
+| results[].whale_trades[].quantity | float | Trade quantity |
+| results[].net_pressure | float | Net buy - sell volume in USD |
+| results[].buy_volume | float | Total buy volume in USD |
+| results[].sell_volume | float | Total sell volume in USD |
+| results[].biggest_trade | object | Largest single trade |
+
+---
+
+## Tool 3: simulate_market_impact
+
+Walks the order book to calculate real slippage, fill levels, and impact cost.
+
+### Binance Endpoints Used
+
+| Endpoint | Method | Parameters |
+|----------|--------|------------|
+| `/fapi/v1/depth` | GET | symbol, limit=1000 |
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbol | str | No | BTCUSDT | Trading pair |
+| side | str | No | BUY | `"BUY"` or `"SELL"` |
+| amount_usd | float | No | 100000 | Order size in USD |
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tool | string | `"simulate_market_impact"` |
+| symbol | string | Trading pair |
+| side | string | Order side |
+| amount_usd | float | Requested order size |
+| market_price | float | Current best price |
+| avg_fill_price | float | Volume-weighted average fill price |
+| worst_fill_price | float | Price of the last level consumed |
+| slippage_pct | float | Slippage percentage from market price |
+| impact_cost_usd | float | Total slippage cost in USD |
+| levels_consumed | integer | Number of order book levels consumed |
+| total_quantity | float | Total quantity filled |
+| filled_pct | float | Percentage of order filled (< 100 if book exhausted) |
+
+### Example Response
+
 ```json
 {
-  "name": "classify_market_regime",
-  "arguments": {
-    "symbols": ["BTCUSDT", "ETHUSDT"]
+  "tool": "simulate_market_impact",
+  "symbol": "BTCUSDT",
+  "side": "BUY",
+  "amount_usd": 100000,
+  "market_price": 68542.10,
+  "avg_fill_price": 68543.25,
+  "worst_fill_price": 68548.90,
+  "slippage_pct": 0.0017,
+  "impact_cost_usd": 1.68,
+  "levels_consumed": 12,
+  "total_quantity": 1.459,
+  "filled_pct": 100.0
+}
+```
+
+---
+
+## Tool 4: smart_money_radar
+
+6-factor composite positioning analysis combining top trader, global, and taker data.
+
+### Binance Endpoints Used
+
+| Endpoint | Method | Parameters |
+|----------|--------|------------|
+| `/futures/data/topLongShortPositionRatio` | GET | symbol, period=4h, limit=30 |
+| `/futures/data/topLongShortAccountRatio` | GET | symbol, period=4h, limit=30 |
+| `/futures/data/globalLongShortAccountRatio` | GET | symbol, period=4h, limit=30 |
+| `/futures/data/takerlongshortRatio` | GET | symbol, period=4h, limit=30 |
+| `/futures/data/openInterestHist` | GET | symbol, period=4h, limit=30 |
+| `/fapi/v1/klines` | GET | symbol, interval=4h, limit=30 |
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbols | list[str] | No | Top 12 futures pairs | Symbols to analyze |
+
+### Factor Scores
+
+| Factor | Source | Range | Logic |
+|--------|--------|-------|-------|
+| position_ratio | topLongShortPositionRatio | -1 to +1 | Top trader position trend |
+| account_ratio | topLongShortAccountRatio | -1 to +1 | Top trader account trend |
+| global_sentiment | globalLongShortAccountRatio | -1 to +1 | Global long/short sentiment |
+| taker_pressure | takerlongshortRatio | -1 to +1 | Buyer vs seller aggression |
+| oi_momentum | openInterestHist | -1 to +1 | Open interest trend direction |
+| price_momentum | klines | -1 to +1 | Price direction alignment |
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tool | string | `"smart_money_radar"` |
+| count | integer | Successfully analyzed symbols |
+| results | array | Sorted by composite score descending |
+| results[].symbol | string | Trading pair |
+| results[].factors | object | Individual factor scores (-1 to +1) |
+| results[].composite | float | Weighted composite score (0-100) |
+| results[].signal | string | `"STRONG_BULLISH"`, `"BULLISH"`, `"NEUTRAL"`, `"BEARISH"`, `"STRONG_BEARISH"` |
+
+---
+
+## Tool 5: scan_candlestick_patterns
+
+Detects classic candlestick patterns with confidence scores.
+
+### Binance Endpoints Used
+
+| Endpoint | Method | Parameters |
+|----------|--------|------------|
+| `/fapi/v1/klines` | GET | symbol, interval, limit=50 |
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbols | list[str] | No | Top 12 futures pairs | Symbols to scan |
+| interval | str | No | 4h | Kline interval: `"1h"` or `"4h"` |
+
+### Detected Patterns
+
+| Pattern | Direction | Detection Logic |
+|---------|-----------|----------------|
+| Hammer | BULLISH | Small body at top, long lower wick >= 2x body |
+| Inverted Hammer | BULLISH | Small body at bottom, long upper wick >= 2x body |
+| Bullish Engulfing | BULLISH | Green candle body fully engulfs prior red candle |
+| Bearish Engulfing | BEARISH | Red candle body fully engulfs prior green candle |
+| Doji | NEUTRAL | Body < 10% of total range |
+| Morning Star | BULLISH | 3-candle reversal: red, small body/doji, green |
+| Evening Star | BEARISH | 3-candle reversal: green, small body/doji, red |
+| Three White Soldiers | BULLISH | 3 consecutive green candles with higher closes |
+| Three Black Crows | BEARISH | 3 consecutive red candles with lower closes |
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tool | string | `"scan_candlestick_patterns"` |
+| count | integer | Symbols with detected patterns |
+| results | array | Per-symbol pattern data |
+| results[].symbol | string | Trading pair |
+| results[].patterns | array | Detected patterns |
+| results[].patterns[].pattern | string | Pattern name |
+| results[].patterns[].direction | string | `"BULLISH"`, `"BEARISH"`, or `"NEUTRAL"` |
+| results[].patterns[].confidence | float | Confidence score (0-100) |
+
+---
+
+## Tool 6: compute_correlation_matrix
+
+Calculates Pearson correlation matrix from close price series.
+
+### Binance Endpoints Used
+
+| Endpoint | Method | Parameters |
+|----------|--------|------------|
+| `/fapi/v1/klines` | GET | symbol, interval, limit (per symbol) |
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbols | list[str] | No | Top 12 futures pairs | 4-12 symbols for correlation |
+| interval | str | No | 4h | Kline interval |
+| limit | int | No | 90 | Number of candles for correlation window |
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tool | string | `"compute_correlation_matrix"` |
+| symbols | array | Ordered symbol list |
+| matrix | array[array] | NxN Pearson correlation matrix (-1.0 to +1.0) |
+| strongest_pair | object | Highest positive correlation pair |
+| weakest_pair | object | Most negative correlation pair |
+
+### Example Response
+
+```json
+{
+  "tool": "compute_correlation_matrix",
+  "symbols": ["BTCUSDT", "ETHUSDT", "SOLUSDT"],
+  "matrix": [
+    [1.0, 0.87, 0.72],
+    [0.87, 1.0, 0.81],
+    [0.72, 0.81, 1.0]
+  ],
+  "strongest_pair": {
+    "pair": ["BTCUSDT", "ETHUSDT"],
+    "correlation": 0.87
+  },
+  "weakest_pair": {
+    "pair": ["BTCUSDT", "SOLUSDT"],
+    "correlation": 0.72
   }
 }
 ```
 
-**Response**:
+---
+
+## Tool 7: classify_market_regime
+
+Classifies market regime using ADX, ATR, and volume analysis.
+
+### Binance Endpoints Used
+
+| Endpoint | Method | Parameters |
+|----------|--------|------------|
+| `/fapi/v1/klines` | GET | symbol, interval=1h, limit=168 |
+| `/fapi/v1/premiumIndex` | GET | symbol |
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbols | list[str] | No | Top 12 futures pairs | Symbols to classify |
+
+### Regime Classification Logic
+
+| Regime | Condition | Description |
+|--------|-----------|-------------|
+| VOLATILE_BREAKOUT | ADX >= 40 and ATR% >= 1.5% | High directional momentum with expanding volatility |
+| TRENDING | ADX >= 25 | Sustained directional movement |
+| LOW_ACTIVITY | ATR% < 0.5% and volume change < 20% | Low volatility, low volume |
+| RANGING | Default | Sideways price action |
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tool | string | `"classify_market_regime"` |
+| count | integer | Successfully classified symbols |
+| regime_summary | object | Symbols grouped by regime |
+| results | array | Per-symbol classification |
+| results[].symbol | string | Trading pair |
+| results[].regime | string | `"TRENDING"`, `"RANGING"`, `"VOLATILE_BREAKOUT"`, `"LOW_ACTIVITY"` |
+| results[].direction | string | `"UP"` or `"DOWN"` (only for TRENDING/VOLATILE_BREAKOUT) |
+| results[].indicators.adx | float | Average Directional Index value |
+| results[].indicators.plus_di | float | Positive Directional Indicator |
+| results[].indicators.minus_di | float | Negative Directional Indicator |
+| results[].indicators.atr | float | Average True Range (absolute) |
+| results[].indicators.atr_pct | float | ATR as percentage of price |
+| results[].indicators.volume_change_pct | float | Recent vs older volume change % |
+| results[].indicators.funding_rate | float | Current funding rate |
+
+### Example Response
+
 ```json
 {
   "tool": "classify_market_regime",
@@ -345,37 +442,95 @@ All endpoints are **public** and require **no authentication**.
         "funding_rate": 0.000125
       }
     }
-  ]
+  ],
+  "errors": []
 }
 ```
 
-## Testing
+---
 
-```bash
-# Clone and install
-git clone https://github.com/mefai-dev/binance-intelligence-mcp.git
-cd binance-intelligence-mcp
-pip install -e ".[dev]"
+## Tool 8: backtest_dca
 
-# Run 142 tests (all mock-based, no API keys needed)
-pytest tests/ -v
+Compares Dollar-Cost Averaging vs lump-sum investment over historical data.
+
+### Binance Endpoints Used
+
+| Endpoint | Method | Parameters |
+|----------|--------|------------|
+| `/fapi/v1/klines` | GET | symbol, interval=1d, limit=total_days |
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbol | str | No | BTCUSDT | Trading pair |
+| amount | float | No | 100 | USD per buy interval |
+| interval_days | int | No | 7 | Days between each DCA buy |
+| total_days | int | No | 365 | Total backtest period in days |
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tool | string | `"backtest_dca"` |
+| symbol | string | Trading pair |
+| dca.total_invested | float | Total USD invested via DCA |
+| dca.current_value | float | Current portfolio value |
+| dca.total_quantity | float | Total quantity accumulated |
+| dca.average_cost | float | Average cost per unit |
+| dca.num_buys | integer | Number of DCA purchases |
+| dca.roi_pct | float | DCA return on investment % |
+| lump_sum.total_invested | float | Total USD invested at day 0 |
+| lump_sum.current_value | float | Current lump-sum portfolio value |
+| lump_sum.roi_pct | float | Lump-sum return on investment % |
+| winner | string | `"DCA"` or `"LUMP_SUM"` |
+
+### Example Response
+
+```json
+{
+  "tool": "backtest_dca",
+  "symbol": "BTCUSDT",
+  "dca": {
+    "total_invested": 5200,
+    "current_value": 6142.50,
+    "total_quantity": 0.0892,
+    "average_cost": 58295.96,
+    "num_buys": 52,
+    "roi_pct": 18.13
+  },
+  "lump_sum": {
+    "total_invested": 5200,
+    "current_value": 5876.40,
+    "roi_pct": 13.01
+  },
+  "winner": "DCA"
+}
 ```
 
-## Key Differentiators
+---
 
-| Feature | Raw API Wrappers | This Package |
-|---------|-----------------|--------------|
-| Data | Pass-through | Computed intelligence |
-| Endpoints per tool | 1 | 2-6 combined |
-| Output | Raw JSON | Scores, signals, classifications |
-| Algorithms | None | ADX, ATR, Pearson, linear regression, pattern detection |
-| API Keys | Often required | Never needed |
-| Rate Limiting | Manual | Built-in semaphore |
+## Binance API Endpoints Reference
 
-## Source Code
+All endpoints below are **public** — no API key or authentication required.
 
-Full source: [github.com/mefai-dev/binance-intelligence-mcp](https://github.com/mefai-dev/binance-intelligence-mcp)
+| Endpoint | Base URL | Description |
+|----------|----------|-------------|
+| `GET /fapi/v1/klines` | fapi.binance.com | Futures kline/candlestick data |
+| `GET /fapi/v1/aggTrades` | fapi.binance.com | Futures compressed aggregate trades |
+| `GET /fapi/v1/depth` | fapi.binance.com | Futures order book depth |
+| `GET /fapi/v1/premiumIndex` | fapi.binance.com | Premium index and funding rate |
+| `GET /futures/data/openInterestHist` | fapi.binance.com | Open interest statistics history |
+| `GET /futures/data/topLongShortPositionRatio` | fapi.binance.com | Top trader long/short position ratio |
+| `GET /futures/data/topLongShortAccountRatio` | fapi.binance.com | Top trader long/short account ratio |
+| `GET /futures/data/globalLongShortAccountRatio` | fapi.binance.com | Global long/short account ratio |
+| `GET /futures/data/takerlongshortRatio` | fapi.binance.com | Taker buy/sell volume ratio |
 
-## License
+## Notes
 
-MIT
+1. All tools use **Binance Futures public endpoints only** — zero API keys needed
+2. Rate limiting is handled internally via asyncio Semaphore (max 10 concurrent requests)
+3. Default symbols: BTCUSDT, ETHUSDT, BNBUSDT, SOLUSDT, XRPUSDT, DOGEUSDT, ADAUSDT, AVAXUSDT, DOTUSDT, MATICUSDT, LINKUSDT, LTCUSDT
+4. All scores are normalized to 0-100 range
+5. Factor scores in smart_money_radar are normalized to -1 to +1 range
+6. Install via `pip install binance-intelligence-mcp`, run via `python -m binance_intelligence`

--- a/skills/binance/intelligence-mcp/SKILL.md
+++ b/skills/binance/intelligence-mcp/SKILL.md
@@ -1,0 +1,381 @@
+---
+name: intelligence-mcp
+description: |
+  MCP server providing 8 computed intelligence tools for Binance futures markets.
+  Unlike raw API wrappers, each tool combines multiple Binance public endpoints into
+  derived analytics: smart accumulation detection, whale footprint scanning, market
+  impact simulation, smart money radar (6-factor), candlestick pattern recognition,
+  pair correlation matrix, market regime classification (ADX/ATR), and DCA backtesting.
+  Install via pip, no API keys needed — all public endpoints.
+metadata:
+  author: mefai-dev
+  version: "1.0.0"
+license: MIT
+---
+
+# Binance Intelligence MCP Server
+
+MCP (Model Context Protocol) server with 8 computed intelligence tools for Binance. Each tool combines 2-4 Binance public API endpoints into composite analytics that go beyond raw data forwarding.
+
+## Installation
+
+```bash
+pip install binance-intelligence-mcp
+```
+
+Or run directly:
+```bash
+python -m binance_intelligence
+```
+
+## Architecture
+
+```
+User / LLM
+    ↓  MCP (stdio)
+binance-intelligence-mcp
+    ↓  aiohttp (async)
+Binance Public API (fapi.binance.com / api.binance.com)
+```
+
+- **Transport**: stdio (standard MCP pattern)
+- **Dependencies**: `mcp>=1.0.0`, `aiohttp>=3.9.0`
+- **Python**: >=3.10
+- **API Keys**: None required (all public endpoints)
+
+## 8 Intelligence Tools
+
+### 1. `detect_accumulation` — Smart Accumulation Detector
+
+Identifies stealth institutional buying before price moves.
+
+| Sub-Score | Source Endpoint | Logic |
+|-----------|----------------|-------|
+| volume_surge | `GET /fapi/v1/klines` (4h, 30) | Current volume vs 20-period moving average |
+| oi_buildup | `GET /futures/data/openInterestHist` (4h, 30) | Linear regression slope of OI, normalized by mean |
+| stealth_mode | `GET /fapi/v1/premiumIndex` | Funding rate proximity to zero (quiet accumulation) |
+| buyer_aggression | `GET /futures/data/takerlongshortRatio` (4h) | Taker buy ratio deviation from neutral 0.5 |
+
+**Output**: Composite score 0-100 per symbol, signal: STRONG (≥70) / MODERATE (≥45) / WEAK
+
+**Parameters**:
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbols | list[str] | No | Top 12 futures pairs | Symbols to analyze |
+
+---
+
+### 2. `scan_whale_trades` — Whale Footprint Scanner
+
+Detects large trades and classifies them by size.
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /fapi/v1/aggTrades` (500 per symbol) | Aggregate trade data |
+
+**Classification**:
+- DOLPHIN: $50K – $250K
+- WHALE: $250K – $1M
+- MEGA: > $1M
+
+**Output**: Trade list with side (buy/sell), net pressure, biggest trade per symbol
+
+**Parameters**:
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbols | list[str] | No | Top 12 | Symbols to scan |
+| min_usd | float | No | 50000 | Minimum trade size in USD |
+
+---
+
+### 3. `simulate_market_impact` — Market Impact Simulator
+
+Walks the order book to calculate real slippage for large orders.
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /fapi/v1/depth` (1000 levels) | Full order book |
+
+**Output**: Average fill price, worst fill price, slippage %, levels consumed, impact cost
+
+**Parameters**:
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbol | str | No | BTCUSDT | Trading pair |
+| side | str | No | BUY | BUY or SELL |
+| amount_usd | float | No | 100000 | Order size in USD |
+
+---
+
+### 4. `smart_money_radar` — Smart Money Radar (6-Factor)
+
+Composite positioning analysis from 6 independent signals.
+
+| Factor | Source Endpoint | Metric |
+|--------|----------------|--------|
+| Top Position L/S | `GET /futures/data/topLongShortPositionRatio` | Position ratio trend |
+| Top Account L/S | `GET /futures/data/topLongShortAccountRatio` | Account ratio trend |
+| Global L/S | `GET /futures/data/globalLongShortAccountRatio` | Global sentiment |
+| Taker Ratio | `GET /futures/data/takerlongshortRatio` | Buyer vs seller aggression |
+| OI Trend | `GET /futures/data/openInterestHist` | Open interest momentum |
+| Price Momentum | `GET /fapi/v1/klines` | Price direction alignment |
+
+**Output**: 6 factor scores (-1 to +1), composite 0-100, signal: STRONG_BULLISH / BULLISH / NEUTRAL / BEARISH / STRONG_BEARISH
+
+**Parameters**:
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbols | list[str] | No | Top 12 | Symbols to analyze |
+
+---
+
+### 5. `scan_candlestick_patterns` — Candlestick Pattern Scanner
+
+Detects classic candlestick patterns with confidence scores.
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /fapi/v1/klines` (50 candles) | OHLCV data |
+
+**Detected Patterns**: Hammer, Inverted Hammer, Bullish Engulfing, Bearish Engulfing, Doji, Morning Star, Evening Star, Three White Soldiers, Three Black Crows
+
+**Output**: Pattern name, direction (BULLISH/BEARISH), confidence 0-100
+
+**Parameters**:
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbols | list[str] | No | Top 12 | Symbols to scan |
+| interval | str | No | 4h | Kline interval (1h/4h) |
+
+---
+
+### 6. `compute_correlation_matrix` — Pair Correlation Matrix
+
+Calculates Pearson correlation between trading pairs from close prices.
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /fapi/v1/klines` (4h, 90 candles per symbol) | Close price series |
+
+**Output**: NxN correlation matrix (-1 to +1), strongest/weakest pairs
+
+**Parameters**:
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbols | list[str] | No | Top 12 | 4-12 symbols |
+| interval | str | No | 4h | Kline interval |
+| limit | int | No | 90 | Number of candles |
+
+---
+
+### 7. `classify_market_regime` — Market Regime Classifier
+
+Classifies regime using ADX, ATR, and volume analysis.
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /fapi/v1/klines` (1h, 168) | 7 days of hourly data |
+| `GET /fapi/v1/premiumIndex` | Funding rate context |
+
+**Regimes**:
+| Regime | Condition |
+|--------|-----------|
+| TRENDING | ADX ≥ 25 |
+| VOLATILE_BREAKOUT | ADX ≥ 40 and ATR% ≥ 1.5% |
+| LOW_ACTIVITY | ATR% < 0.5% and volume change < 20% |
+| RANGING | Default (low ADX, moderate ATR) |
+
+**Output**: Regime label, direction (UP/DOWN for trending), ADX, ATR, volume change %, funding rate
+
+**Parameters**:
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbols | list[str] | No | Top 12 | Symbols to classify |
+
+---
+
+### 8. `backtest_dca` — DCA Backtester
+
+Compares Dollar-Cost Averaging vs lump-sum investment over historical data.
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /fapi/v1/klines` (1d, up to 365) | Daily close prices |
+
+**Output**: Total invested, DCA final value, DCA ROI%, lump-sum value, lump-sum ROI%, number of buys, average cost
+
+**Parameters**:
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| symbol | str | No | BTCUSDT | Trading pair |
+| amount | float | No | 100 | USD per interval |
+| interval_days | int | No | 7 | Days between buys |
+| total_days | int | No | 365 | Backtest period |
+
+---
+
+## Binance API Endpoints Used
+
+All endpoints are **public** and require **no authentication**.
+
+| Endpoint | Type | Used By |
+|----------|------|---------|
+| `GET /fapi/v1/klines` | Futures | accumulation, patterns, correlation, regime, smart_money, dca |
+| `GET /fapi/v1/aggTrades` | Futures | whale |
+| `GET /fapi/v1/depth` | Futures | impact |
+| `GET /fapi/v1/premiumIndex` | Futures | accumulation, regime |
+| `GET /futures/data/openInterestHist` | Futures | accumulation, smart_money |
+| `GET /futures/data/topLongShortPositionRatio` | Futures | smart_money |
+| `GET /futures/data/topLongShortAccountRatio` | Futures | smart_money |
+| `GET /futures/data/globalLongShortAccountRatio` | Futures | smart_money |
+| `GET /futures/data/takerlongshortRatio` | Futures | accumulation, smart_money |
+
+## How It Works
+
+```
+┌─────────────────────────────────────────────────┐
+│              MCP Server (stdio)                  │
+│  8 @mcp.tool() functions                         │
+│                                                   │
+│  detect_accumulation  ─┐                          │
+│  scan_whale_trades    ─┤                          │
+│  simulate_market_impact┤   BinanceClient          │
+│  smart_money_radar    ─┤   (async, aiohttp)       │
+│  scan_candlestick     ─┤   - rate limiting        │
+│  compute_correlation  ─┤   - connection pooling    │
+│  classify_market_regime┤   - no API keys           │
+│  backtest_dca         ─┘                          │
+│                                                   │
+│  Each tool: validate → fetch 2-4 endpoints →      │
+│  compute derived scores → return structured JSON   │
+└─────────────────────────────────────────────────┘
+```
+
+## Example Usage
+
+### MCP Configuration
+
+```json
+{
+  "mcpServers": {
+    "binance-intelligence": {
+      "command": "binance-intelligence-mcp"
+    }
+  }
+}
+```
+
+### Example: Accumulation Detection
+
+**Request** (via MCP tool call):
+```json
+{
+  "name": "detect_accumulation",
+  "arguments": {
+    "symbols": ["BTCUSDT", "ETHUSDT", "SOLUSDT"]
+  }
+}
+```
+
+**Response**:
+```json
+{
+  "tool": "detect_accumulation",
+  "count": 3,
+  "results": [
+    {
+      "symbol": "SOLUSDT",
+      "scores": {
+        "volume_surge": 72.5,
+        "oi_buildup": 68.3,
+        "stealth_mode": 85.1,
+        "buyer_aggression": 61.2
+      },
+      "composite": 71.4,
+      "signal": "STRONG"
+    },
+    {
+      "symbol": "BTCUSDT",
+      "scores": {
+        "volume_surge": 45.2,
+        "oi_buildup": 52.1,
+        "stealth_mode": 78.4,
+        "buyer_aggression": 48.7
+      },
+      "composite": 55.8,
+      "signal": "MODERATE"
+    }
+  ]
+}
+```
+
+### Example: Market Regime Classification
+
+**Request**:
+```json
+{
+  "name": "classify_market_regime",
+  "arguments": {
+    "symbols": ["BTCUSDT", "ETHUSDT"]
+  }
+}
+```
+
+**Response**:
+```json
+{
+  "tool": "classify_market_regime",
+  "count": 2,
+  "regime_summary": {
+    "TRENDING": ["BTCUSDT"],
+    "RANGING": ["ETHUSDT"]
+  },
+  "results": [
+    {
+      "symbol": "BTCUSDT",
+      "regime": "TRENDING",
+      "direction": "UP",
+      "indicators": {
+        "adx": 35.72,
+        "plus_di": 28.41,
+        "minus_di": 12.53,
+        "atr": 1250.45,
+        "atr_pct": 1.823,
+        "volume_change_pct": 15.34,
+        "funding_rate": 0.000125
+      }
+    }
+  ]
+}
+```
+
+## Testing
+
+```bash
+# Clone and install
+git clone https://github.com/mefai-dev/binance-intelligence-mcp.git
+cd binance-intelligence-mcp
+pip install -e ".[dev]"
+
+# Run 142 tests (all mock-based, no API keys needed)
+pytest tests/ -v
+```
+
+## Key Differentiators
+
+| Feature | Raw API Wrappers | This Package |
+|---------|-----------------|--------------|
+| Data | Pass-through | Computed intelligence |
+| Endpoints per tool | 1 | 2-6 combined |
+| Output | Raw JSON | Scores, signals, classifications |
+| Algorithms | None | ADX, ATR, Pearson, linear regression, pattern detection |
+| API Keys | Often required | Never needed |
+| Rate Limiting | Manual | Built-in semaphore |
+
+## Source Code
+
+Full source: [github.com/mefai-dev/binance-intelligence-mcp](https://github.com/mefai-dev/binance-intelligence-mcp)
+
+## License
+
+MIT

--- a/skills/binance/intelligence-mcp/SKILL.md
+++ b/skills/binance/intelligence-mcp/SKILL.md
@@ -1,15 +1,10 @@
 ---
-name: intelligence-mcp
-description: |
-  Computed intelligence tools for Binance futures markets. Combines multiple public Binance API endpoints
-  into derived analytics: accumulation detection, whale trade scanning, market impact simulation,
-  smart money positioning, candlestick pattern recognition, pair correlation, regime classification, and DCA backtesting.
-  Use this skill when users ask about market conditions, smart money activity, accumulation signals,
-  whale trades, order book impact, candlestick patterns, asset correlations, market regime, or DCA strategy comparison.
-  All endpoints are public — no API keys required.
+title: Binance Intelligence MCP
+description: 8 computed intelligence tools for Binance futures markets. Combines multiple public API endpoints into derived analytics including accumulation detection, whale trade scanning, market impact simulation, smart money radar, candlestick pattern recognition, pair correlation matrix, market regime classification, and DCA backtesting. Use this skill when users ask about market conditions, smart money activity, accumulation signals, whale trades, order book slippage, candlestick patterns, asset correlations, market regime, or DCA vs lump-sum strategy comparison. All endpoints are public and no API keys are required.
 metadata:
-  author: mefai-dev
   version: "1.0.0"
+  author: mefai-dev
+license: MIT
 ---
 
 # Binance Intelligence MCP Skill


### PR DESCRIPTION
## Summary

Adds **4 new funding rate analysis tools** to the `binance-intelligence-mcp` package (v1.1.0).

| Tool | Function | Endpoints |
|----|--------|----------|
| `scan_funding_rates` | Funding rate heatmap across all futures pairs | premiumIndex + fundingInfo |
| `detect_funding_extremes` | Extreme funding arbitrage opportunity detector | premiumIndex + fundingInfo |
| `analyze_funding_history` | Historical funding rate analysis with trend & cost projections | fundingRate |
| `scan_basis_spread` | Spot-futures basis spread scanner (contango/backwardation) | premiumIndex |

## Details

- All tools use only **public Binance Futures endpoints** — no API keys required
- Endpoints: `/fapi/v1/premiumIndex`, `/fapi/v1/fundingInfo`, `/fapi/v1/fundingRate`
- 213 tests passing (all mock-based)
- Install: `pip install binance-intelligence-mcp`
- Source: https://github.com/mefai-dev/binance-intelligence-mcp

## Checklist

- [x] SKILL.md follows the required format
- [x] All endpoints documented with parameters and response fields
- [x] Example responses included for each tool
- [x] MIT licensed