### PR TITLE
docs(readme): align contribution template frontmatter with existing skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ To add a new skill:
 
    ```markdown
    ---
-   title: <Skill Name>
+   name: <skill-name>
    description: A clear description of what the skill does and when to use it.
    metadata:
-     version: <Skill Version>
-     author: <Your Github Username>
+     version: <Skill Version> # e.g., 1.0.0 (semantic versioning recommended)
+     author: <Your GitHub Username>
    license: MIT
    ---
 


### PR DESCRIPTION
## What changed

Updated the contribution example in `README.md` to match the frontmatter style used by existing skills:

- `title` -> `name`
- normalized `GitHub` capitalization in author field
- added a short semver hint for `metadata.version`

## Why

Current examples can cause contributors to submit inconsistent frontmatter.
This small docs fix reduces review friction and improves first-time contribution success.

## Scope

Docs only. No runtime or API behavior changes.