### PR TITLE
docs: add PR template to standardize skill submissions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+Describe what changed and why.
+
+## Change Type
+
+- [ ] New skill
+- [ ] Skill update
+- [ ] Docs only
+- [ ] Other
+
+## Skill Submission Checklist
+
+- [ ] Skill files are under `skills/<provider>/<skill-name>/`
+- [ ] `SKILL.md` exists
+- [ ] Frontmatter includes `name`, `description`, `metadata.version`, `metadata.author`
+- [ ] `name` uses kebab-case
+- [ ] Example usage/API snippets are accurate
+- [ ] No secrets or private credentials in commits
+
+## Validation
+
+- [ ] Self-reviewed changes
+- [ ] Tested examples/requests where applicable
+- [ ] Docs updated if behavior/usage changed
+
+## Notes for Reviewers
+
+Any extra context or tradeoffs.


### PR DESCRIPTION
## What changed

Added `.github/pull_request_template.md` with a concise checklist for skill contributions:

- required location and file structure
- required frontmatter fields
- naming and secrets checks
- validation/self-review prompts

## Why

With high concurrent PR volume, a template helps contributors pre-validate changes and reduces repetitive review comments.

## Scope

Docs/process only. No runtime/API behavior changes.