### PR TITLE
ci: add minimal validation for SKILL.md required frontmatter

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,16 @@
+name: Validate Skills
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  frontmatter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate SKILL.md frontmatter
+        run: ./scripts/validate-skills-frontmatter.sh

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -2,8 +2,6 @@ name: Validate Skills
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 jobs:
   frontmatter:

--- a/scripts/validate-skills-frontmatter.sh
+++ b/scripts/validate-skills-frontmatter.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail=0
+
+while IFS= read -r -d '' file; do
+  frontmatter=$(awk 'BEGIN{in=0} /^---$/{if(in==0){in=1;next}else{exit}} in{print}' "$file")
+
+  if [[ -z "$frontmatter" ]]; then
+    echo "[ERROR] Missing frontmatter: $file"
+    fail=1
+    continue
+  fi
+
+  if ! grep -Eq '^name:' <<<"$frontmatter"; then
+    echo "[ERROR] Missing 'name' in $file"
+    fail=1
+  fi
+
+  if ! grep -Eq '^description:' <<<"$frontmatter"; then
+    echo "[ERROR] Missing 'description' in $file"
+    fail=1
+  fi
+
+  if ! grep -Eq '^metadata:' <<<"$frontmatter"; then
+    echo "[ERROR] Missing 'metadata' in $file"
+    fail=1
+  fi
+
+  if ! grep -Eq '^[[:space:]]+version:' <<<"$frontmatter"; then
+    echo "[ERROR] Missing 'metadata.version' in $file"
+    fail=1
+  fi
+
+  if ! grep -Eq '^[[:space:]]+author:' <<<"$frontmatter"; then
+    echo "[ERROR] Missing 'metadata.author' in $file"
+    fail=1
+  fi
+done < <(find skills -type f -name 'SKILL.md' -print0)
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "\nFrontmatter validation failed."
+  exit 1
+fi
+
+echo "Frontmatter validation passed."

--- a/scripts/validate-skills-frontmatter.sh
+++ b/scripts/validate-skills-frontmatter.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 fail=0
 
 while IFS= read -r -d '' file; do
-  frontmatter=$(awk 'BEGIN{in=0} /^---$/{if(in==0){in=1;next}else{exit}} in{print}' "$file")
+  frontmatter=$(awk 'BEGIN{infm=0} /^---$/{if(infm==0){infm=1;next}else{exit}} infm{print}' "$file")
 
   if [[ -z "$frontmatter" ]]; then
     echo "[ERROR] Missing frontmatter: $file"
@@ -13,33 +13,34 @@ while IFS= read -r -d '' file; do
   fi
 
   if ! grep -Eq '^name:' <<<"$frontmatter"; then
-    echo "[ERROR] Missing 'name' in $file"
+    echo "[ERROR] Missing name in $file"
     fail=1
   fi
 
   if ! grep -Eq '^description:' <<<"$frontmatter"; then
-    echo "[ERROR] Missing 'description' in $file"
+    echo "[ERROR] Missing description in $file"
     fail=1
   fi
 
   if ! grep -Eq '^metadata:' <<<"$frontmatter"; then
-    echo "[ERROR] Missing 'metadata' in $file"
+    echo "[ERROR] Missing metadata in $file"
     fail=1
   fi
 
   if ! grep -Eq '^[[:space:]]+version:' <<<"$frontmatter"; then
-    echo "[ERROR] Missing 'metadata.version' in $file"
+    echo "[ERROR] Missing metadata.version in $file"
     fail=1
   fi
 
   if ! grep -Eq '^[[:space:]]+author:' <<<"$frontmatter"; then
-    echo "[ERROR] Missing 'metadata.author' in $file"
+    echo "[ERROR] Missing metadata.author in $file"
     fail=1
   fi
 done < <(find skills -type f -name 'SKILL.md' -print0)
 
 if [[ "$fail" -ne 0 ]]; then
-  echo "\nFrontmatter validation failed."
+  echo
+  echo "Frontmatter validation failed."
   exit 1
 fi
 


### PR DESCRIPTION
## What changed

Added a minimal CI guard for skill metadata quality:

- `scripts/validate-skills-frontmatter.sh`
- `.github/workflows/validate-skills.yml`

The check validates that every `skills/**/SKILL.md` includes frontmatter and these required fields:

- `name`
- `description`
- `metadata`
- `metadata.version`
- `metadata.author`

## Why

This repository has high PR volume. A lightweight automated check catches common formatting omissions before manual review.

## Scope

Process/CI only. No API/runtime behavior changes.
