### PR TITLE
feat: add skillshub web3 skills pack (39 skills)

### DIFF
--- a/skills/binance-web3/ai-quick-chat/SKILL.md
+++ b/skills/binance-web3/ai-quick-chat/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: ai_quick_chat
 description: Sends a short prompt to OpenRouter-compatible LLM for capability verification.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # AI Quick Chat

--- a/skills/binance-web3/bap578-adapter-blueprint/SKILL.md
+++ b/skills/binance-web3/bap578-adapter-blueprint/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: bap578_adapter_blueprint
 description: Generates a simple adapter contract blueprint for token-bound agent accounts.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # BAP578 Adapter Blueprint

--- a/skills/binance-web3/bap578-contract-idea-sprint/SKILL.md
+++ b/skills/binance-web3/bap578-contract-idea-sprint/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: bap578_contract_idea_sprint
 description: Turns a product idea into a minimal BAP578 contract task list.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # BAP578 Contract Idea Sprint

--- a/skills/binance-web3/bap578-deploy-plan/SKILL.md
+++ b/skills/binance-web3/bap578-deploy-plan/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: bap578_deploy_plan
 description: Builds a deploy+verify execution plan from environment variables.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # BAP578 Deploy Plan

--- a/skills/binance-web3/bap578-test-template/SKILL.md
+++ b/skills/binance-web3/bap578-test-template/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: bap578_test_template
 description: Generates Hardhat test skeleton for adapter + vault flows.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # BAP578 Test Template

--- a/skills/binance-web3/bap578-vault-checklist/SKILL.md
+++ b/skills/binance-web3/bap578-vault-checklist/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: bap578_vault_checklist
 description: Outputs a concise checklist for vault-controller and operator safety.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # BAP578 Vault Checklist

--- a/skills/binance-web3/bitagent-bonding-playbook/SKILL.md
+++ b/skills/binance-web3/bitagent-bonding-playbook/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: bitagent_bonding_playbook
 description: Provides guarded execution playbook for launch/buy/sell flows on BSC bonding-curve products.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # BitAgent Bonding Playbook

--- a/skills/binance-web3/bsc-honeypot-check/SKILL.md
+++ b/skills/binance-web3/bsc-honeypot-check/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: bsc_honeypot_check
 description: Checks sell restrictions, tax anomalies, and multi-DEX liquidity signals before buy-in.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # BSC Honeypot Check

--- a/skills/binance-web3/bsc-nft-ops-guide/SKILL.md
+++ b/skills/binance-web3/bsc-nft-ops-guide/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: bsc_nft_ops_guide
 description: Guides ERC-721 metadata, ownership checks, and transfer-safe operational flow on BSC.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # BSC NFT Ops Guide

--- a/skills/binance-web3/bsc-rpc-fanout-check/SKILL.md
+++ b/skills/binance-web3/bsc-rpc-fanout-check/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: bsc_rpc_fanout_check
 description: Validates BSC RPC endpoints for health, latency, and block drift.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # BSC RPC Fanout Check

--- a/skills/binance-web3/crowding-risk-scan/SKILL.md
+++ b/skills/binance-web3/crowding-risk-scan/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: crowding_risk_scan
 description: Tracks long/short crowding from account ratios, taker flow, and OI change for squeeze warnings.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Crowding Risk Scan

--- a/skills/binance-web3/cz-style-rewrite/SKILL.md
+++ b/skills/binance-web3/cz-style-rewrite/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: cz_style_rewrite
 description: Rewrites or generates a post in CZ-inspired style using dataset-derived profile cues.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # CZ Style Rewrite

--- a/skills/binance-web3/dev-launch-streak-radar/SKILL.md
+++ b/skills/binance-web3/dev-launch-streak-radar/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dev_launch_streak_radar
 description: Detects whether a launcher wallet keeps opening new Pancake pairs on consecutive days and returns streak/risk signals. Use when users ask if a dev is continuously launching tokens, repeatedly opening markets, or needs launch-frequency risk checks on BSC.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Dev Launch Streak Radar

--- a/skills/binance-web3/erc8004-agent-registry/SKILL.md
+++ b/skills/binance-web3/erc8004-agent-registry/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: erc8004_agent_registry
 description: Generates deployment and operation checklist for ERC-8004-style agent identity and reputation registries.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # ERC8004 Agent Registry

--- a/skills/binance-web3/erc8004-fast-auth/SKILL.md
+++ b/skills/binance-web3/erc8004-fast-auth/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: erc8004_fast_auth
 description: Implements a fast authorization runbook for ERC-8004 agent identity operations using ERC-721 approvals and immediate revoke controls. Use when users ask for quick agent authorization, delegated execution windows, or session-scoped operator permissions.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # ERC8004 Fast Auth

--- a/skills/binance-web3/finclaw-meme-monitor-playbook/SKILL.md
+++ b/skills/binance-web3/finclaw-meme-monitor-playbook/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: finclaw_meme_monitor_playbook
 description: Adapts FinClaw's social-signal and market-analysis flow into a Four.meme candidate discovery and manual-launch decision playbook.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # FinClaw Meme Monitor Playbook

--- a/skills/binance-web3/four-meme-agentic-ops/SKILL.md
+++ b/skills/binance-web3/four-meme-agentic-ops/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: four_meme_agentic_ops
 description: Runs a human-in-the-loop agentic operating loop for Four.meme (discover, score, confirm, execute, monitor, and journal). Use when users ask for automated strategy support without granting fully autonomous hot-wallet trading.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Four.Meme Agentic Ops

--- a/skills/binance-web3/four-meme-ai/SKILL.md
+++ b/skills/binance-web3/four-meme-ai/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: four_meme_ai
 description: Installs and exposes the official four-meme-ai CLI skill so Hub agents can run create/buy/sell/send flows on Four.Meme directly from chats.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Four.Meme Agent Skill Bridge

--- a/skills/binance-web3/four-meme-bitquery-query-kit/SKILL.md
+++ b/skills/binance-web3/four-meme-bitquery-query-kit/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: four_meme_bitquery_query_kit
 description: Provides a query-first analytics toolkit for Four.meme using Bitquery GraphQL/streams (trades, bonding progress, migrations, liquidity, and trader behavior).
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Four.Meme Bitquery Query Kit

--- a/skills/binance-web3/four-meme-create-pipeline/SKILL.md
+++ b/skills/binance-web3/four-meme-create-pipeline/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: four_meme_create_pipeline
 description: Plans and executes Four.meme two-step token creation (create-api then create-chain) with confirmation gates, fee sanity checks, and post-create verification. Use when users ask to launch or issue a new token on Four.meme from an agent workflow.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Four.Meme Create Pipeline
@@ -20,7 +23,7 @@ description: Plans and executes Four.meme two-step token creation (create-api th
   "name": "Meme Agent Coin",
   "symbol": "MAC",
   "description": "Agent launch token for BSC growth",
-  "logoPath": "./assets/mac.png",
+  "logoPath": "/path/to/logo.png",
   "label": "Meme",
   "budgetBnb": 0.01,
   "dryRun": true

--- a/skills/binance-web3/four-meme-graduation-radar/SKILL.md
+++ b/skills/binance-web3/four-meme-graduation-radar/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: four_meme_graduation_radar
 description: Tracks graduation and migration signals from Four.meme bonding curves to Pancake liquidity using rankings, listing flags, and LiquidityAdded events.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Four.Meme Graduation Radar

--- a/skills/binance-web3/four-meme-mcp-ops-guard/SKILL.md
+++ b/skills/binance-web3/four-meme-mcp-ops-guard/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: four_meme_mcp_ops_guard
 description: Hardens Four.meme MCP-server operations with read-only defaults, explicit trade confirmations, and secret-isolation policies.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Four.Meme MCP Ops Guard

--- a/skills/binance-web3/four-meme-mempool-sentinel/SKILL.md
+++ b/skills/binance-web3/four-meme-mempool-sentinel/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: four_meme_mempool_sentinel
 description: Builds real-time pending-transaction watchlists for Four.meme and upgrades alerts only after event-level confirmation, reducing false positives.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Four.Meme Mempool Sentinel

--- a/skills/binance-web3/four-meme-one-stop-bsc/SKILL.md
+++ b/skills/binance-web3/four-meme-one-stop-bsc/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: four_meme_one_stop_bsc
 description: Runs a one-stop Four.meme workflow that combines token launch, buy execution, tweet material generation, ERC8004 identity setup, and fast operator authorization with revoke discipline. Use when users ask for an end-to-end Four.meme execution playbook instead of separate skills.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Four.Meme One-Stop Launch

--- a/skills/binance-web3/four-meme-tax-token-guard/SKILL.md
+++ b/skills/binance-web3/four-meme-tax-token-guard/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: four_meme_tax_token_guard
 description: Plans TaxToken creation with fee-split sanity checks, anti-sniping defaults, explicit confirmation gates, and post-launch tax-info reconciliation.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Four.Meme Tax Token Guard

--- a/skills/binance-web3/four-meme-trade-playbook/SKILL.md
+++ b/skills/binance-web3/four-meme-trade-playbook/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: four_meme_trade_playbook
 description: Creates quote-first Four.meme buy and sell execution plans with slippage, loss limits, and event-level reconciliation. Use when users ask to buy, sell, scale in, or scale out Four.meme tokens.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Four.Meme Trade Playbook

--- a/skills/binance-web3/funding-basis-carry-scan/SKILL.md
+++ b/skills/binance-web3/funding-basis-carry-scan/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: funding_basis_carry_scan
 description: Combines funding history and basis term structure to surface carry setups with risk labels.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Funding Basis Carry Scan

--- a/skills/binance-web3/funding-watch/SKILL.md
+++ b/skills/binance-web3/funding-watch/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: funding_watch
 description: Reads funding rate, annualized estimate, and mark-index basis from Binance Futures.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Funding Watch

--- a/skills/binance-web3/kline-brief/SKILL.md
+++ b/skills/binance-web3/kline-brief/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: kline_brief
 description: Summarizes recent candles with trend percentage.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Kline Brief

--- a/skills/binance-web3/kryptogo-cluster-radar/SKILL.md
+++ b/skills/binance-web3/kryptogo-cluster-radar/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: kryptogo_cluster_radar
 description: Read-only token intelligence workflow adapted from KryptoGO cluster analysis. Tracks whale and smart-money accumulation across BSC/Solana/Base/Monad with trading flows omitted from current integration scope.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # KryptoGO Cluster Radar (Read-Only)

--- a/skills/binance-web3/liquidation-heatmap/SKILL.md
+++ b/skills/binance-web3/liquidation-heatmap/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: liquidation_heatmap
 description: Aggregates recent force orders to estimate long-vs-short liquidation pressure.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Liquidation Heatmap

--- a/skills/binance-web3/multichain-portfolio-tracker/SKILL.md
+++ b/skills/binance-web3/multichain-portfolio-tracker/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: multichain_portfolio_tracker
 description: Outlines cross-chain portfolio analysis workflow for TRON/ETH/BSC with position and fee breakdown.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Multichain Portfolio Tracker

--- a/skills/binance-web3/open-interest-scan/SKILL.md
+++ b/skills/binance-web3/open-interest-scan/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: open_interest_scan
 description: Tracks futures open interest and taker flow changes for a symbol.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Open Interest Scan

--- a/skills/binance-web3/pancakeswap-trading-guard/SKILL.md
+++ b/skills/binance-web3/pancakeswap-trading-guard/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: pancakeswap_trading_guard
 description: Builds pre-trade checklist and execution guardrails for BSC PancakeSwap workflows.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # PancakeSwap Trading Guard

--- a/skills/binance-web3/prediction-market-clob/SKILL.md
+++ b/skills/binance-web3/prediction-market-clob/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: prediction_market_clob
 description: Provides orderbook trading and risk-control playbook for BSC prediction-market CLOB integrations.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Prediction Market CLOB

--- a/skills/binance-web3/price-snapshot/SKILL.md
+++ b/skills/binance-web3/price-snapshot/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: price_snapshot
 description: Fetches spot last price and 24h change for one trading pair.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Price Snapshot

--- a/skills/binance-web3/symbol-status/SKILL.md
+++ b/skills/binance-web3/symbol-status/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: symbol_status
 description: Checks trading status and filters from exchangeInfo.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Symbol Status Checker

--- a/skills/binance-web3/syncx/SKILL.md
+++ b/skills/binance-web3/syncx/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: syncx
 description: One-command SyncX workflow for cross-posting crypto content to Binance Square and X/Twitter, with optional Telegram and Threads targets.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # SyncX Multi-Platform Publisher
@@ -23,26 +26,31 @@ description: One-command SyncX workflow for cross-posting crypto content to Bina
 
 ## Workflow
 
-1. Initialize local config:
+1. Clone SyncX repo and enter project directory:
+   ```bash
+   git clone https://github.com/SyncX2026/SyncX.git
+   cd SyncX
+   ```
+2. Initialize local config:
    ```bash
    python3 scripts/publish_sync.py --init-config
    ```
-2. Fill `.env` with platform credentials.
-3. Run doctor checks before any publish:
+3. Fill `.env` with platform credentials.
+4. Run doctor checks before any publish:
    ```bash
    python3 scripts/publish_sync.py \
      --doctor \
      --platforms square,twitter \
      --twitter-mode official
    ```
-4. Publish once and fan out by platform:
+5. Publish once and fan out by platform:
    ```bash
    python3 scripts/publish_sync.py \
      --text "BTC retrace then continuation; watch 4h structure." \
      --platforms square,twitter \
      --twitter-mode official
    ```
-5. Use dry-run for safe validation:
+6. Use dry-run for safe validation:
    ```bash
    python3 scripts/publish_sync.py \
      --text "test" \
@@ -68,5 +76,4 @@ description: One-command SyncX workflow for cross-posting crypto content to Bina
 ## Source Anchors
 
 - Repo: https://github.com/SyncX2026/SyncX
-- Skill root: `skills/syncx`
-- Script entrypoint: `skills/syncx/scripts/publish_sync.py`
+- Script entrypoint: https://github.com/SyncX2026/SyncX/blob/main/scripts/publish_sync.py

--- a/skills/binance-web3/top-movers/SKILL.md
+++ b/skills/binance-web3/top-movers/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: top_movers
 description: Ranks top symbols by 24h change or quote volume with optional liquidity filter.
+metadata:
+  author: brief-onchain
+  version: "1.0"
 ---
 
 # Top Movers Radar


### PR DESCRIPTION
 ## Summary
  - Add 39 new skills under `skills/binance-web3/`
  - Cover BSC market intelligence, BAP578 dev workflows, and ecosystem
  operation playbooks
  - Keep scope limited to skill definition docs (`SKILL.md`) only

  ## What’s Included
  - **Market & signals**: top movers, funding watch, liquidation heatmap,
  open-interest scan, kline brief, crowding risk scan, etc.
  - **BAP578**: adapter blueprint, contract idea sprint, deploy plan, test
  template, vault checklist
  - **Ecosystem intake**: Four.meme workflows, ERC-8004 flows, prediction
  market, portfolio tracking, SyncX, and related playbooks

  ## Quality Notes
  - Added/normalized frontmatter metadata (`name`, `description`,
  `metadata.author`, `metadata.version`)
  - Updated ambiguous local path references to clearer source anchors
  where needed
  - No token secrets, private keys, binaries, or unrelated code changes

  ## Validation
  - Branch is mergeable against `main`
  - Change set is additive and focused on new skill docs