### PR TITLE
Add risk warnings to Futures, Margin, and Assets skills

### DIFF
--- a/skills/binance/assets/SKILL.md
+++ b/skills/binance/assets/SKILL.md
@@ -242,3 +242,9 @@ Otherwise, do not perform steps 3–5.
 Include `User-Agent` header with the following string: `binance-wallet/1.0.0 (Skill)`
 
 See [`references/authentication.md`](./references/authentication.md) for implementation details.
+
+## Risk Warnings
+
+- **Withdrawals are irreversible**: Once a withdrawal is confirmed on the blockchain, it cannot be reversed. Always verify the destination address and network.
+- **Network Selection**: Selecting the wrong network for withdrawals will result in permanent loss of funds. Ensure the destination address supports the selected network.
+- **Minimum Withdrawal**: Each asset has a minimum withdrawal amount. Withdrawals below this threshold will be rejected.

--- a/skills/binance/derivatives-trading-usds-futures/SKILL.md
+++ b/skills/binance/derivatives-trading-usds-futures/SKILL.md
@@ -322,3 +322,11 @@ Example: `agent-1a2b3c4d5e6f7g8h9i`
 Include `User-Agent` header with the following string: `binance-derivatives-trading-usds-futures/1.0.0 (Skill)`
 
 See [`references/authentication.md`](./references/authentication.md) for implementation details.
+
+## Risk Warnings
+
+- **Leverage Risk**: Futures trading with leverage amplifies both gains and losses. Higher leverage increases liquidation risk.
+- **Liquidation**: Positions may be liquidated if margin falls below maintenance margin. Monitor margin ratio closely.
+- **Funding Rate**: Perpetual futures incur funding fees every 8 hours. High funding rates can significantly impact position costs.
+- **Market Orders**: Market orders execute at the best available price, which may differ from the last traded price during high volatility.
+- **Position Mode**: Ensure correct position mode (One-Way or Hedge) is set before placing orders. Switching modes requires closing all positions.

--- a/skills/binance/margin-trading/SKILL.md
+++ b/skills/binance/margin-trading/SKILL.md
@@ -295,3 +295,10 @@ Example: `agent-1a2b3c4d5e6f7g8h9i`
 Include `User-Agent` header with the following string: `binance-margin-trading/1.0.0 (Skill)`
 
 See [`references/authentication.md`](./references/authentication.md) for implementation details.
+
+## Risk Warnings
+
+- **Liquidation Risk**: Borrowed assets must be repaid. If collateral value drops below the liquidation threshold, positions will be force-liquidated.
+- **Interest Rates**: Borrowed assets accrue hourly interest. Rates vary by asset and market conditions.
+- **Cross vs Isolated**: Cross margin shares collateral across all positions. Isolated margin limits risk to the specific position but increases per-position liquidation risk.
+- **Auto-Repay**: Some operations may trigger automatic repayment of borrowed assets.


### PR DESCRIPTION
## Summary
- Add risk warning sections to three trading-related skills to help users understand critical risks before executing trades or withdrawals

## Type of Change
- [x] Improvement to existing skill

## Changes Made
- Added Risk Warnings section to Futures skill covering leverage, liquidation, funding rates, market orders, and position mode
- Added Risk Warnings section to Margin Trading skill covering liquidation, interest rates, cross vs isolated margin, and auto-repay
- Added Risk Warnings section to Assets skill covering irreversible withdrawals, network selection, and minimum withdrawal amounts

## Testing
- [x] Changes follow existing SKILL.md format
- [x] No breaking changes to skill structure