### PR TITLE
Add cross-references between all skills for better discoverability

### DIFF
--- a/skills/binance-web3/crypto-market-rank/SKILL.md
+++ b/skills/binance-web3/crypto-market-rank/SKILL.md
@@ -437,3 +437,9 @@ Include `User-Agent` header with the following string: `binance-web3/2.0 (Skill)
 2. Unified Token Rank supports both GET and POST; POST is recommended
 3. All numeric fields in responses are strings — parse when needed
 4. Period fields use shorthand: `{1m,5m,1h,4h,24h}` means separate fields like `percentChange1m`, `percentChange5m`, etc.
+
+## Related Skills
+
+- [query-token-info](../query-token-info/) — Detailed token information and market data
+- [trading-signal](../trading-signal/) — Smart money trading signals for ranked tokens
+- [meme-rush](../meme-rush/) — Meme token launchpad tracking and topic discovery

--- a/skills/binance-web3/meme-rush/SKILL.md
+++ b/skills/binance-web3/meme-rush/SKILL.md
@@ -352,3 +352,9 @@ Include `User-Agent` header with the following string: `binance-web3/1.0 (Skill)
 2. Percentage fields (progress, holder %, dev sell %, tax rate) are pre-formatted — append `%` directly
 3. `taxRate` for protocol=2001 (Four.meme) only shows on Migrated list; for protocol=2002 (Flap) shows on all lists
 4. Icon URLs require prefix: `https://bin.bnbstatic.com` + path
+
+## Related Skills
+
+- [query-token-audit](../query-token-audit/) — Security audit before trading meme tokens
+- [crypto-market-rank](../crypto-market-rank/) — Broader market rankings and Alpha discovery
+- [trading-signal](../trading-signal/) — Smart money signals for tokens of interest

--- a/skills/binance-web3/query-address-info/SKILL.md
+++ b/skills/binance-web3/query-address-info/SKILL.md
@@ -121,3 +121,8 @@ Include `User-Agent` header with the following string: `binance-web3/1.0 (Skill)
 1. Icon URL requires full domain prefix: `bin.bnbstatic.com` + icon path
 2. Price and quantity are string format, convert to numbers when using
 3. Use offset parameter for pagination
+
+## Related Skills
+
+- [query-token-info](../query-token-info/) — Detailed token information for held assets
+- [crypto-market-rank](../crypto-market-rank/) — Market rankings and PnL leaderboards

--- a/skills/binance-web3/query-token-audit/SKILL.md
+++ b/skills/binance-web3/query-token-audit/SKILL.md
@@ -158,3 +158,8 @@ Include `User-Agent` header with the following string: `binance-web3/1.4 (Skill)
 5. Generate unique UUID v4 for each audit request
 6. Only output security check risk flags, do NOT provide any investment advice 
 7. Always end with disclaimer: `⚠️ This audit result is for reference only and does not constitute investment advice. Always conduct your own research.`
+
+## Related Skills
+
+- [query-token-info](../query-token-info/) — Token details and market data for audited tokens
+- [meme-rush](../meme-rush/) — Meme token discovery with risk filtering

--- a/skills/binance-web3/query-token-info/SKILL.md
+++ b/skills/binance-web3/query-token-info/SKILL.md
@@ -450,3 +450,9 @@ Include `User-Agent` header with the following string: `binance-web3/1.0 (Skill)
 3. Dynamic data updates in real-time, suitable for market display
 4. K-Line API uses `platform` (eth/bsc/solana/base) instead of `chainId`, and `limit` takes priority over `from` when both are provided
 5. K-Line response is a 2D array (not JSON objects) — parse by index: [open, high, low, close, volume, timestamp, count]
+
+## Related Skills
+
+- [query-token-audit](../query-token-audit/) — Security audit before trading a token
+- [trading-signal](../trading-signal/) — Smart money signals for token trading opportunities
+- [crypto-market-rank](../crypto-market-rank/) — Market rankings and trending token discovery

--- a/skills/binance-web3/trading-signal/SKILL.md
+++ b/skills/binance-web3/trading-signal/SKILL.md
@@ -245,3 +245,9 @@ curl --location 'https://web3.binance.com/bapi/defi/v1/public/wallet-direct/buw/
 5. Signals may timeout (status=timeout), focus on active signals
 6. Higher smartMoneyCount may indicate higher signal reliability
 7. exitRate shows smart money exit status, high exitRate may indicate expired signal
+
+## Related Skills
+
+- [query-token-info](../query-token-info/) — Token details and market data for signal tokens
+- [query-token-audit](../query-token-audit/) — Security audit before acting on signals
+- [crypto-market-rank](../crypto-market-rank/) — Market rankings and smart money inflow data

--- a/skills/binance/alpha/SKILL.md
+++ b/skills/binance/alpha/SKILL.md
@@ -141,3 +141,8 @@ Otherwise, do not perform steps 3–5.
 Include `User-Agent` header with the following string: `binance-alpha/1.0.0 (Skill)`
 
 See [`references/authentication.md`](./references/authentication.md) for implementation details.
+
+## Related Skills
+
+- [spot](../spot/) — Spot trading for tokens discovered through Alpha
+- [crypto-market-rank](../../binance-web3/crypto-market-rank/) — Market rankings including Alpha token rankings

--- a/skills/binance/assets/SKILL.md
+++ b/skills/binance/assets/SKILL.md
@@ -242,3 +242,8 @@ Otherwise, do not perform steps 3–5.
 Include `User-Agent` header with the following string: `binance-wallet/1.0.0 (Skill)`
 
 See [`references/authentication.md`](./references/authentication.md) for implementation details.
+
+## Related Skills
+
+- [spot](../spot/) — Spot trading operations
+- [margin-trading](../margin-trading/) — Margin trading with borrowed assets

--- a/skills/binance/derivatives-trading-usds-futures/SKILL.md
+++ b/skills/binance/derivatives-trading-usds-futures/SKILL.md
@@ -322,3 +322,9 @@ Example: `agent-1a2b3c4d5e6f7g8h9i`
 Include `User-Agent` header with the following string: `binance-derivatives-trading-usds-futures/1.0.0 (Skill)`
 
 See [`references/authentication.md`](./references/authentication.md) for implementation details.
+
+## Related Skills
+
+- [spot](../spot/) — Spot trading operations
+- [assets](../assets/) — Deposit, withdrawal, and asset management
+- [margin-trading](../margin-trading/) — Margin trading with borrowed assets

--- a/skills/binance/margin-trading/SKILL.md
+++ b/skills/binance/margin-trading/SKILL.md
@@ -295,3 +295,9 @@ Example: `agent-1a2b3c4d5e6f7g8h9i`
 Include `User-Agent` header with the following string: `binance-margin-trading/1.0.0 (Skill)`
 
 See [`references/authentication.md`](./references/authentication.md) for implementation details.
+
+## Related Skills
+
+- [spot](../spot/) — Spot trading operations
+- [assets](../assets/) — Deposit, withdrawal, and asset management
+- [derivatives-trading-usds-futures](../derivatives-trading-usds-futures/) — Futures trading with leverage

--- a/skills/binance/spot/SKILL.md
+++ b/skills/binance/spot/SKILL.md
@@ -343,3 +343,9 @@ Example: `agent-1a2b3c4d5e6f7g8h9i`
 Include `User-Agent` header with the following string: `binance-spot/1.0.2 (Skill)`
 
 See [`references/authentication.md`](./references/authentication.md) for implementation details.
+
+## Related Skills
+
+- [derivatives-trading-usds-futures](../derivatives-trading-usds-futures/) — Futures trading with leverage for hedging or speculation
+- [margin-trading](../margin-trading/) — Margin trading with borrowed assets
+- [assets](../assets/) — Deposit, withdrawal, and asset management

--- a/skills/binance/square-post/SKILL.md
+++ b/skills/binance/square-post/SKILL.md
@@ -157,3 +157,8 @@ Accounts:
 
 1. Only pure text posts are supported currently
 2. Check daily post limit to avoid 220009 error
+
+## Related Skills
+
+- [crypto-market-rank](../../binance-web3/crypto-market-rank/) — Market rankings and trending data for post content
+- [query-token-info](../../binance-web3/query-token-info/) — Token details to enrich posts with market data


### PR DESCRIPTION
## Summary
- Add Related Skills section to all 12 SKILL.md files with relative links, enabling skill discovery and navigation between related capabilities

## Type of Change
- [x] Improvement to existing skill

## Changes Made
- Added Related Skills section to all 12 skills (6 CEX + 6 Web3)
- Each skill links to 2-3 most relevant related skills with brief descriptions
- Used relative paths for cross-linking between binance/ and binance-web3/ directories
- CEX skills (spot, futures, margin, assets, alpha, square-post) cross-reference each other
- Web3 skills (crypto-market-rank, meme-rush, query-address-info, query-token-audit, query-token-info, trading-signal) cross-reference each other

## Testing
- [x] Changes follow existing SKILL.md format
- [x] No breaking changes to skill structure