### PR TITLE
Add rate limit documentation to all CEX skills

### DIFF
--- a/skills/binance/alpha/SKILL.md
+++ b/skills/binance/alpha/SKILL.md
@@ -35,6 +35,15 @@ Alpha request on Binance using authenticated API endpoints. Requires API key and
 * **interval**: e.g., "1h" – supported intervals: 1s, 15s, 1m, 3m, 5m, 15m, 30m, 1h, 2h, 4h, 6h, 8h, 12h, 1d, 3d, 1w, 1M
 
 
+## Rate Limits
+
+| Type | Limit |
+|------|-------|
+| Request Weight | 1200/min |
+| Raw Requests | 6100/5min |
+
+Each endpoint has a specific weight. Check `X-MBX-USED-WEIGHT` response header to monitor usage.
+
 ## Authentication
 
 For endpoints that require authentication, you will need to provide Binance API credentials.

--- a/skills/binance/assets/SKILL.md
+++ b/skills/binance/assets/SKILL.md
@@ -135,6 +135,16 @@ Assets request on Binance using authenticated API endpoints. Requires API key an
 * **tranId**: Wallet tran ID (e.g., 1)
 
 
+## Rate Limits
+
+| Type | Limit |
+|------|-------|
+| Request Weight | 1200/min |
+| Order Rate | 10/s per symbol |
+| Raw Requests | 6100/5min |
+
+Each endpoint has a specific weight. Check `X-MBX-USED-WEIGHT` response header to monitor usage.
+
 ## Authentication
 
 For endpoints that require authentication, you will need to provide Binance API credentials.

--- a/skills/binance/margin-trading/SKILL.md
+++ b/skills/binance/margin-trading/SKILL.md
@@ -182,6 +182,16 @@ Margin-trading request on Binance using authenticated API endpoints. Requires AP
 * **timeInForce**: GTC | IOC | FOK
 
 
+## Rate Limits
+
+| Type | Limit |
+|------|-------|
+| Request Weight | 1200/min |
+| Order Rate | 10/s per symbol |
+| Raw Requests | 6100/5min |
+
+Each endpoint has a specific weight. Check `X-MBX-USED-WEIGHT` response header to monitor usage.
+
 ## Authentication
 
 For endpoints that require authentication, you will need to provide Binance API credentials.

--- a/skills/binance/spot/SKILL.md
+++ b/skills/binance/spot/SKILL.md
@@ -212,6 +212,16 @@ Spot request on Binance using authenticated API endpoints. Requires API key and 
 * **pendingBelowTimeInForce**: GTC | IOC | FOK
 
 
+## Rate Limits
+
+| Type | Limit |
+|------|-------|
+| Request Weight | 1200/min |
+| Order Rate | 10/s per symbol |
+| Raw Requests | 6100/5min |
+
+Each endpoint has a specific weight. Check `X-MBX-USED-WEIGHT` response header to monitor usage.
+
 ## Authentication
 
 For endpoints that require authentication, you will need to provide Binance API credentials.


### PR DESCRIPTION
## Summary
- Add rate limit documentation to Spot, Margin Trading, Assets, and Alpha skills to help developers avoid rate limiting issues

## Type of Change
- [x] Improvement to existing skill

## Changes Made
- Added Rate Limits section to Spot skill (1200/min request weight, 10/s per symbol, 6100/5min raw)
- Added Rate Limits section to Margin Trading skill (same limits as Spot)
- Added Rate Limits section to Assets skill (same limits as Spot)
- Added Rate Limits section to Alpha skill (1200/min request weight, 6100/5min raw)
- All sections include note about X-MBX-USED-WEIGHT response header for monitoring

## Testing
- [x] Changes follow existing SKILL.md format
- [x] No breaking changes to skill structure