### PR TITLE
Fix Ed25519 signing command typo: pkeyut → pkeyutl

### DIFF
--- a/skills/binance/alpha/references/authentication.md
+++ b/skills/binance/alpha/references/authentication.md
@@ -67,7 +67,7 @@ Create Ed25519 signature of the query string using your private key:
 ```bash
 # Example using openssl
 echo -n "symbol=...&timestamp=1234567890123" | \
-  openssl pkeyut -pubout -in private_key.pem -outform DER | \
+  openssl pkeyutl -pubout -in private_key.pem -outform DER | \
   openssl dgst -sha256 -sign private_key.pem | base64
 ```
 

--- a/skills/binance/assets/references/authentication.md
+++ b/skills/binance/assets/references/authentication.md
@@ -67,7 +67,7 @@ Create Ed25519 signature of the query string using your private key:
 ```bash
 # Example using openssl
 echo -n "timestamp=1234567890123" | \
-  openssl pkeyut -pubout -in private_key.pem -outform DER | \
+  openssl pkeyutl -pubout -in private_key.pem -outform DER | \
   openssl dgst -sha256 -sign private_key.pem | base64
 ```
 

--- a/skills/binance/derivatives-trading-usds-futures/references/authentication.md
+++ b/skills/binance/derivatives-trading-usds-futures/references/authentication.md
@@ -68,7 +68,7 @@ Create Ed25519 signature of the query string using your private key:
 ```bash
 # Example using openssl
 echo -n "symbol=BTCUSDT&side=BUY&type=MARKET&quantity=0.001&timestamp=1234567890123" | \
-  openssl pkeyut -pubout -in private_key.pem -outform DER | \
+  openssl pkeyutl -pubout -in private_key.pem -outform DER | \
   openssl dgst -sha256 -sign private_key.pem | base64
 ```
 

--- a/skills/binance/margin-trading/references/authentication.md
+++ b/skills/binance/margin-trading/references/authentication.md
@@ -67,7 +67,7 @@ Create Ed25519 signature of the query string using your private key:
 ```bash
 # Example using openssl
 echo -n "timestamp=1234567890123" | \
-  openssl pkeyut -pubout -in private_key.pem -outform DER | \
+  openssl pkeyutl -pubout -in private_key.pem -outform DER | \
   openssl dgst -sha256 -sign private_key.pem | base64
 ```
 

--- a/skills/binance/spot/references/authentication.md
+++ b/skills/binance/spot/references/authentication.md
@@ -68,7 +68,7 @@ Create Ed25519 signature of the query string using your private key:
 ```bash
 # Example using openssl
 echo -n "symbol=BTCUSDT&side=BUY&type=MARKET&quantity=0.001&timestamp=1234567890123" | \
-  openssl pkeyut -pubout -in private_key.pem -outform DER | \
+  openssl pkeyutl -pubout -in private_key.pem -outform DER | \
   openssl dgst -sha256 -sign private_key.pem | base64
 ```
 


### PR DESCRIPTION
## Summary
- Fixed `pkeyut` (nonexistent command) to `pkeyutl` in Ed25519 signing examples across all 5 authentication reference files

## Type of Change
- [x] Bug fix

## Changes Made
- `openssl pkeyut` → `openssl pkeyutl` in spot, alpha, assets, derivatives-futures, and margin-trading authentication references
- `pkeyut` is not a valid OpenSSL subcommand; `pkeyutl` is the correct command for key utility operations

## Testing
- [x] Verified `openssl pkeyutl` is the correct command
- [x] All 5 files updated consistently