### PR TITLE
Fix copy-pasted 'spot trading' in non-spot security notes

### DIFF
--- a/skills/binance/assets/references/authentication.md
+++ b/skills/binance/assets/references/authentication.md
@@ -115,4 +115,4 @@ curl -X GET "${BASE_URL}/sapi/v1/account/apiTradingStatus?${QUERY}&signature=${S
 
 * Never share your secret key
 * Use IP whitelist in Binance API settings
-* Enable only required permissions (spot trading, no withdrawals)
+* Enable only required permissions (wallet and asset management, no withdrawals)

--- a/skills/binance/derivatives-trading-usds-futures/references/authentication.md
+++ b/skills/binance/derivatives-trading-usds-futures/references/authentication.md
@@ -122,6 +122,6 @@ If you get -1021 Timestamp outside recvWindow:
 
 * Never share your secret key
 * Use IP whitelist in Binance API settings
-* Enable only required permissions (spot trading, no withdrawals)
+* Enable only required permissions (futures trading, no withdrawals)
 * Use testnet for development: https://demo-fapi.binance.com
 * Testnet credentials are separate from mainnet

--- a/skills/binance/margin-trading/references/authentication.md
+++ b/skills/binance/margin-trading/references/authentication.md
@@ -115,4 +115,4 @@ curl -X GET "${BASE_URL}/sapi/v1/margin/isolated/account?${QUERY}&signature=${SI
 
 * Never share your secret key
 * Use IP whitelist in Binance API settings
-* Enable only required permissions (spot trading, no withdrawals)
+* Enable only required permissions (margin trading, no withdrawals)


### PR DESCRIPTION
## Summary
- Fixed copy-paste error from Spot skill where non-spot authentication references incorrectly say "spot trading"

## Type of Change
- [x] Bug fix

## Changes Made
- Derivatives futures: "spot trading" → "futures trading"
- Margin trading: "spot trading" → "margin trading"
- Assets: "spot trading" → "wallet and asset management"

## Testing
- [x] Each file now correctly references its own trading context
- [x] Original spot authentication reference left unchanged (correct as-is)