### PR TITLE
Fix User-Agent mismatch in Assets skill: binance-wallet → binance-assets

### DIFF
--- a/skills/binance/assets/SKILL.md
+++ b/skills/binance/assets/SKILL.md
@@ -239,6 +239,6 @@ Otherwise, do not perform steps 3–5.
 
 ## User Agent Header
 
-Include `User-Agent` header with the following string: `binance-wallet/1.0.0 (Skill)`
+Include `User-Agent` header with the following string: `binance-assets/1.0.0 (Skill)`
 
 See [`references/authentication.md`](./references/authentication.md) for implementation details.

--- a/skills/binance/assets/references/authentication.md
+++ b/skills/binance/assets/references/authentication.md
@@ -11,7 +11,7 @@ All trading endpoints require HMAC SHA256 signed requests.
 ## Required Headers
 
 * `X-MBX-APIKEY`: your_api_key
-* `User-Agent`: binance-wallet/1.0.0 (Skill)
+* `User-Agent`: binance-assets/1.0.0 (Skill)
 
 ## Signing Process
 
@@ -78,7 +78,7 @@ Add signature parameter to the query string:
 
 ### Step 5: Add Product User Agent Header
 
-Include `User-Agent` header with the following string: `binance-wallet/1.0.0 (Skill)`
+Include `User-Agent` header with the following string: `binance-assets/1.0.0 (Skill)`
 
 #### Complete Example
 
@@ -86,7 +86,7 @@ Request:
 ```bash
 curl -X GET "https://api.binance.com/sapi/v1/account/apiTradingStatus" \
   -H "X-MBX-APIKEY: your_api_key" \
-  -H "User-Agent: binance-wallet/1.0.0 (Skill)" \
+  -H "User-Agent: binance-assets/1.0.0 (Skill)" \
   -d "timestamp=1234567890123&signature=..."
 ```
 
@@ -108,7 +108,7 @@ SIGNATURE=$(echo -n "$QUERY" | openssl dgst -sha256 -hmac "$SECRET_KEY" | cut -d
 # Make request
 curl -X GET "${BASE_URL}/sapi/v1/account/apiTradingStatus?${QUERY}&signature=${SIGNATURE}" \
   -H "X-MBX-APIKEY: ${API_KEY}"\
-  -H "User-Agent: binance-wallet/1.0.0 (Skill)"
+  -H "User-Agent: binance-assets/1.0.0 (Skill)"
 ```
 
 ### Security Notes


### PR DESCRIPTION
## Summary
- Fixed User-Agent header to match the actual skill name

## Type of Change
- [x] Bug fix

## Changes Made
- `binance-wallet/1.0.0` → `binance-assets/1.0.0` in SKILL.md and references/authentication.md
- The skill is named `assets` but the User-Agent header incorrectly used `binance-wallet/1.0.0`
- Updated all occurrences for consistency

## Testing
- [x] All User-Agent references now match the skill name
- [x] Both SKILL.md and authentication.md updated consistently