### PR TITLE
Fix missing https:// prefix in query-address-info icon URL note

### DIFF
--- a/skills/binance-web3/query-address-info/SKILL.md
+++ b/skills/binance-web3/query-address-info/SKILL.md
@@ -118,6 +118,6 @@ Include `User-Agent` header with the following string: `binance-web3/1.0 (Skill)
 
 ## Notes
 
-1. Icon URL requires full domain prefix: `bin.bnbstatic.com` + icon path
+1. Icon URL requires full domain prefix: `https://bin.bnbstatic.com` + icon path
 2. Price and quantity are string format, convert to numbers when using
 3. Use offset parameter for pagination


### PR DESCRIPTION
## Summary
- Added missing `https://` protocol prefix to the icon URL documentation

## Type of Change
- [x] Bug fix

## Changes Made
- `bin.bnbstatic.com` → `https://bin.bnbstatic.com` in the Notes section
- The documentation instructs developers to prepend this domain to the icon path, but without the protocol prefix the resulting URL would be invalid

## Testing
- [x] URL now includes proper protocol prefix
- [x] Constructing icon URLs with the documented prefix will produce valid URLs