### PR TITLE
Fix frontmatter template: title → name to match actual skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To add a new skill:
 
    ```markdown
    ---
-   title: <Skill Name>
+   name: <Skill Name>
    description: A clear description of what the skill does and when to use it.
    metadata:
      version: <Skill Version>


### PR DESCRIPTION
## Summary
- Updated the contribution template frontmatter key from `title:` to `name:` to match the format used by all existing skills

## Type of Change
- [x] Bug fix

## Changes Made
- Changed `title: <Skill Name>` → `name: <Skill Name>` in the contribution guide template
- All 12 merged skills (spot, derivatives-futures, margin-trading, assets, alpha, query-address-info, etc.) use `name:` in their frontmatter, not `title:`
- Contributors following the current template would produce skills with incorrect frontmatter

## Testing
- [x] Verified all existing skills use `name:` in YAML frontmatter
- [x] Template now matches actual format