### PR TITLE
Add missing LICENSE.md and CHANGELOG.md to Square-Post skill

### DIFF
--- a/skills/binance/square-post/CHANGELOG.md
+++ b/skills/binance/square-post/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## v1.1
+- Updated skill documentation

--- a/skills/binance/square-post/LICENSE.md
+++ b/skills/binance/square-post/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2026 Binance
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Square-Post is the only skill missing LICENSE.md. It is also missing CHANGELOG.md. Added both files for consistency with all other Binance skills (alpha, assets, derivatives-futures, margin-trading, spot all have both files).