### PR TITLE
Fix formatting inconsistencies in Spot skill parameter descriptions

### DIFF
--- a/skills/binance/spot/SKILL.md
+++ b/skills/binance/spot/SKILL.md
@@ -164,7 +164,7 @@ Spot request on Binance using authenticated API endpoints. Requires API key and 
 * **fromPreventedMatchId**:  (e.g., 1)
 * **orderId**:  (e.g., 1)
 * **fromExecutionId**:  (e.g., 1)
-* **limit**: Default:500; Maximum: 1000 (e.g., 500)
+* **limit**: Default: 500; Maximum: 1000 (e.g., 500)
 
 
 ### Enums


### PR DESCRIPTION
Fixed inconsistent spacing in limit parameter default value formatting (Default:500 -> Default: 500) to match the other limit definition in the same file that uses Default: 500.