### PR TITLE
Fix Futures testnet URL: add real testnet, relabel demo

### DIFF
--- a/skills/binance/derivatives-trading-usds-futures/SKILL.md
+++ b/skills/binance/derivatives-trading-usds-futures/SKILL.md
@@ -202,7 +202,8 @@ Required credentials:
 
 Base URLs:
 * Mainnet: https://fapi.binance.com
-* Testnet: https://demo-fapi.binance.com
+* Testnet: https://testnet.binancefuture.com
+* Demo: https://demo-fapi.binance.com
 
 ## Security
 

--- a/skills/binance/derivatives-trading-usds-futures/references/authentication.md
+++ b/skills/binance/derivatives-trading-usds-futures/references/authentication.md
@@ -7,7 +7,8 @@ All trading endpoints require HMAC SHA256 signed requests.
 | Environment | URL |
 |-------------|-----|
 | Mainnet | https://fapi.binance.com |
-| Testnet | https://demo-fapi.binance.com |
+| Testnet | https://testnet.binancefuture.com |
+| Demo | https://demo-fapi.binance.com |
 
 ## Required Headers
 
@@ -123,5 +124,6 @@ If you get -1021 Timestamp outside recvWindow:
 * Never share your secret key
 * Use IP whitelist in Binance API settings
 * Enable only required permissions (spot trading, no withdrawals)
-* Use testnet for development: https://demo-fapi.binance.com
-* Testnet credentials are separate from mainnet
+* Use testnet for development: https://testnet.binancefuture.com
+* Use demo environment for paper trading: https://demo-fapi.binance.com
+* Testnet and demo credentials are separate from mainnet


### PR DESCRIPTION
The Futures skill listed demo-fapi.binance.com as "Testnet" but this is the Demo trading environment. Added the actual testnet URL (testnet.binancefuture.com) and correctly labeled the demo URL.