### PR TITLE
Fix version format in Square-Post skill to match semver convention

### DIFF
--- a/skills/binance/square-post/SKILL.md
+++ b/skills/binance/square-post/SKILL.md
@@ -6,7 +6,7 @@ description: |
   Supports pure text posts.
 metadata:
   author: binance-square
-  version: "1.1"
+  version: 1.1.0
 ---
 
 # Square Post Skill


### PR DESCRIPTION
Square-Post used "1.1" (quoted, non-semver) while all other Binance skills use unquoted semver format (e.g., 1.0.0). Changed to 1.1.0 for consistency.