### PR TITLE
Fix curl syntax in authentication reference examples

### DIFF
--- a/skills/binance/alpha/references/authentication.md
+++ b/skills/binance/alpha/references/authentication.md
@@ -84,10 +84,9 @@ Include `User-Agent` header with the following string: `binance-alpha/1.0.0 (Ski
 
 Request:
 ```bash
-curl -X GET "https://www.binance.com/bapi/defi/v1/public/alpha-trade/ticker" \
+curl -X GET "https://www.binance.com/bapi/defi/v1/public/alpha-trade/ticker?symbol=...&timestamp=1234567890123&signature=..." \
   -H "X-MBX-APIKEY: your_api_key" \
-  -H "User-Agent: binance-alpha/1.0.0 (Skill)" \
-  -d "symbol=...&timestamp=1234567890123&signature=..."
+  -H "User-Agent: binance-alpha/1.0.0 (Skill)"
 ```
 
 ```bash
@@ -107,7 +106,7 @@ SIGNATURE=$(echo -n "$QUERY" | openssl dgst -sha256 -hmac "$SECRET_KEY" | cut -d
 
 # Make request
 curl -X GET "${BASE_URL}/bapi/defi/v1/public/alpha-trade/ticker?${QUERY}&signature=${SIGNATURE}" \
-  -H "X-MBX-APIKEY: ${API_KEY}"\
+  -H "X-MBX-APIKEY: ${API_KEY}" \
   -H "User-Agent: binance-alpha/1.0.0 (Skill)"
 ```
 

--- a/skills/binance/assets/references/authentication.md
+++ b/skills/binance/assets/references/authentication.md
@@ -84,10 +84,9 @@ Include `User-Agent` header with the following string: `binance-wallet/1.0.0 (Sk
 
 Request:
 ```bash
-curl -X GET "https://api.binance.com/sapi/v1/account/apiTradingStatus" \
+curl -X GET "https://api.binance.com/sapi/v1/account/apiTradingStatus?timestamp=1234567890123&signature=..." \
   -H "X-MBX-APIKEY: your_api_key" \
-  -H "User-Agent: binance-wallet/1.0.0 (Skill)" \
-  -d "timestamp=1234567890123&signature=..."
+  -H "User-Agent: binance-wallet/1.0.0 (Skill)"
 ```
 
 ```bash
@@ -107,7 +106,7 @@ SIGNATURE=$(echo -n "$QUERY" | openssl dgst -sha256 -hmac "$SECRET_KEY" | cut -d
 
 # Make request
 curl -X GET "${BASE_URL}/sapi/v1/account/apiTradingStatus?${QUERY}&signature=${SIGNATURE}" \
-  -H "X-MBX-APIKEY: ${API_KEY}"\
+  -H "X-MBX-APIKEY: ${API_KEY}" \
   -H "User-Agent: binance-wallet/1.0.0 (Skill)"
 ```
 

--- a/skills/binance/derivatives-trading-usds-futures/references/authentication.md
+++ b/skills/binance/derivatives-trading-usds-futures/references/authentication.md
@@ -108,7 +108,7 @@ SIGNATURE=$(echo -n "$QUERY" | openssl dgst -sha256 -hmac "$SECRET_KEY" | cut -d
 
 # Make request
 curl -X POST "${BASE_URL}/fapi/v1/order?${QUERY}&signature=${SIGNATURE}" \
-  -H "X-MBX-APIKEY: ${API_KEY}"\
+  -H "X-MBX-APIKEY: ${API_KEY}" \
   -H "User-Agent: binance-derivatives-trading-usds-futures/1.0.0 (Skill)"
 ```
 

--- a/skills/binance/margin-trading/references/authentication.md
+++ b/skills/binance/margin-trading/references/authentication.md
@@ -84,10 +84,9 @@ Include `User-Agent` header with the following string: `binance-margin-trading/1
 
 Request:
 ```bash
-curl -X GET "https://api.binance.com/sapi/v1/margin/isolated/account" \
+curl -X GET "https://api.binance.com/sapi/v1/margin/isolated/account?timestamp=1234567890123&signature=..." \
   -H "X-MBX-APIKEY: your_api_key" \
-  -H "User-Agent: binance-margin-trading/1.0.0 (Skill)" \
-  -d "timestamp=1234567890123&signature=..."
+  -H "User-Agent: binance-margin-trading/1.0.0 (Skill)"
 ```
 
 ```bash
@@ -107,7 +106,7 @@ SIGNATURE=$(echo -n "$QUERY" | openssl dgst -sha256 -hmac "$SECRET_KEY" | cut -d
 
 # Make request
 curl -X GET "${BASE_URL}/sapi/v1/margin/isolated/account?${QUERY}&signature=${SIGNATURE}" \
-  -H "X-MBX-APIKEY: ${API_KEY}"\
+  -H "X-MBX-APIKEY: ${API_KEY}" \
   -H "User-Agent: binance-margin-trading/1.0.0 (Skill)"
 ```
 

--- a/skills/binance/spot/references/authentication.md
+++ b/skills/binance/spot/references/authentication.md
@@ -108,7 +108,7 @@ SIGNATURE=$(echo -n "$QUERY" | openssl dgst -sha256 -hmac "$SECRET_KEY" | cut -d
 
 # Make request
 curl -X POST "${BASE_URL}/api/v3/order?${QUERY}&signature=${SIGNATURE}" \
-  -H "X-MBX-APIKEY: ${API_KEY}"\
+  -H "X-MBX-APIKEY: ${API_KEY}" \
   -H "User-Agent: binance-spot/1.0.2 (Skill)"
 ```
 


### PR DESCRIPTION
Fixed missing space before line continuation backslash in curl examples across all 5 authentication references. Fixed alpha, assets, and margin auth examples using -d (POST body) for GET endpoints — parameters should be in the URL query string for GET requests.