### PR TITLE
Clarify that Alpha skill endpoints do not require authentication

### DIFF
--- a/skills/binance/alpha/SKILL.md
+++ b/skills/binance/alpha/SKILL.md
@@ -37,6 +37,8 @@ Alpha request on Binance using authenticated API endpoints. Requires API key and
 
 ## Authentication
 
+> **Note:** All endpoints in this skill are currently public and do not require authentication. The authentication reference below is provided for future authenticated endpoints that may be added.
+
 For endpoints that require authentication, you will need to provide Binance API credentials.
 Required credentials:
 


### PR DESCRIPTION
All 5 Alpha endpoints are listed as "Authentication: No" but the skill includes a full authentication section with signing instructions. This is confusing for developers. Added a clarifying note.