### PR TITLE
Fix broken Ed25519 signing pipeline in authentication references

### DIFF
--- a/skills/binance/alpha/references/authentication.md
+++ b/skills/binance/alpha/references/authentication.md
@@ -67,8 +67,7 @@ Create Ed25519 signature of the query string using your private key:
 ```bash
 # Example using openssl
 echo -n "symbol=...&timestamp=1234567890123" | \
-  openssl pkeyut -pubout -in private_key.pem -outform DER | \
-  openssl dgst -sha256 -sign private_key.pem | base64
+  openssl pkeyutl -sign -inkey private_key.pem -rawin | base64
 ```
 
 ### Step 4: Append Signature

--- a/skills/binance/assets/references/authentication.md
+++ b/skills/binance/assets/references/authentication.md
@@ -67,8 +67,7 @@ Create Ed25519 signature of the query string using your private key:
 ```bash
 # Example using openssl
 echo -n "timestamp=1234567890123" | \
-  openssl pkeyut -pubout -in private_key.pem -outform DER | \
-  openssl dgst -sha256 -sign private_key.pem | base64
+  openssl pkeyutl -sign -inkey private_key.pem -rawin | base64
 ```
 
 ### Step 4: Append Signature

--- a/skills/binance/derivatives-trading-usds-futures/references/authentication.md
+++ b/skills/binance/derivatives-trading-usds-futures/references/authentication.md
@@ -68,8 +68,7 @@ Create Ed25519 signature of the query string using your private key:
 ```bash
 # Example using openssl
 echo -n "symbol=BTCUSDT&side=BUY&type=MARKET&quantity=0.001&timestamp=1234567890123" | \
-  openssl pkeyut -pubout -in private_key.pem -outform DER | \
-  openssl dgst -sha256 -sign private_key.pem | base64
+  openssl pkeyutl -sign -inkey private_key.pem -rawin | base64
 ```
 
 ### Step 4: Append Signature

--- a/skills/binance/margin-trading/references/authentication.md
+++ b/skills/binance/margin-trading/references/authentication.md
@@ -67,8 +67,7 @@ Create Ed25519 signature of the query string using your private key:
 ```bash
 # Example using openssl
 echo -n "timestamp=1234567890123" | \
-  openssl pkeyut -pubout -in private_key.pem -outform DER | \
-  openssl dgst -sha256 -sign private_key.pem | base64
+  openssl pkeyutl -sign -inkey private_key.pem -rawin | base64
 ```
 
 ### Step 4: Append Signature

--- a/skills/binance/spot/references/authentication.md
+++ b/skills/binance/spot/references/authentication.md
@@ -68,8 +68,7 @@ Create Ed25519 signature of the query string using your private key:
 ```bash
 # Example using openssl
 echo -n "symbol=BTCUSDT&side=BUY&type=MARKET&quantity=0.001&timestamp=1234567890123" | \
-  openssl pkeyut -pubout -in private_key.pem -outform DER | \
-  openssl dgst -sha256 -sign private_key.pem | base64
+  openssl pkeyutl -sign -inkey private_key.pem -rawin | base64
 ```
 
 ### Step 4: Append Signature


### PR DESCRIPTION
The Ed25519 signing example was logically broken — it piped through `-pubout` (public key export) then into a separate SHA-256 signing step. Ed25519 uses EdDSA which signs directly without a separate hash step. Fixed to use correct single-command `pkeyutl -sign -inkey -rawin` pipeline.