### PR TITLE
Add missing order type enum to Futures skill

### DIFF
--- a/skills/binance/derivatives-trading-usds-futures/SKILL.md
+++ b/skills/binance/derivatives-trading-usds-futures/SKILL.md
@@ -190,6 +190,7 @@ Derivatives-trading-usds-futures request on Binance using authenticated API endp
 * **newOrderRespType**: ACK | RESULT
 * **selfTradePreventionMode**: EXPIRE_TAKER | EXPIRE_BOTH | EXPIRE_MAKER
 * **autoCloseType**: LIQUIDATION | ADL
+* **orderType**: `LIMIT` | `MARKET` | `STOP` | `STOP_MARKET` | `TAKE_PROFIT` | `TAKE_PROFIT_MARKET` | `TRAILING_STOP_MARKET`
 
 
 ## Authentication


### PR DESCRIPTION
The order `type` parameter is required for placing futures orders but was not documented in the Enums section. Added all 7 valid order types.