### PR TITLE
Fix historicalTrades authentication: requires API key header

### DIFF
--- a/skills/binance/derivatives-trading-usds-futures/SKILL.md
+++ b/skills/binance/derivatives-trading-usds-futures/SKILL.md
@@ -61,7 +61,7 @@ Derivatives-trading-usds-futures request on Binance using authenticated API endp
 | `/fapi/v1/markPriceKlines` (GET) | Mark Price Kline/Candlestick Data | symbol, interval | startTime, endTime, limit | No |
 | `/fapi/v1/premiumIndex` (GET) | Mark Price | None | symbol | No |
 | `/fapi/v1/assetIndex` (GET) | Multi-Assets Mode Asset Index | None | symbol | No |
-| `/fapi/v1/historicalTrades` (GET) | Old Trades Lookup (MARKET_DATA) | symbol | limit, fromId | No |
+| `/fapi/v1/historicalTrades` (GET) | Old Trades Lookup (MARKET_DATA) | symbol | limit, fromId | Yes |
 | `/futures/data/openInterestHist` (GET) | Open Interest Statistics | symbol, period | limit, startTime, endTime | No |
 | `/fapi/v1/openInterest` (GET) | Open Interest | symbol | None | No |
 | `/fapi/v1/rpiDepth` (GET) | RPI Order Book | symbol | limit | No |

--- a/skills/binance/spot/SKILL.md
+++ b/skills/binance/spot/SKILL.md
@@ -21,7 +21,7 @@ Spot request on Binance using authenticated API endpoints. Requires API key and 
 | `/api/v3/aggTrades` (GET) | Compressed/Aggregate trades list | symbol | fromId, startTime, endTime, limit | No |
 | `/api/v3/avgPrice` (GET) | Current average price | symbol | None | No |
 | `/api/v3/depth` (GET) | Order book | symbol | limit, symbolStatus | No |
-| `/api/v3/historicalTrades` (GET) | Old trade lookup | symbol | limit, fromId | No |
+| `/api/v3/historicalTrades` (GET) | Old trade lookup | symbol | limit, fromId | Yes |
 | `/api/v3/klines` (GET) | Kline/Candlestick data | symbol, interval | startTime, endTime, timeZone, limit | No |
 | `/api/v3/ticker` (GET) | Rolling window price change statistics | None | symbol, symbols, windowSize, type, symbolStatus | No |
 | `/api/v3/ticker/24hr` (GET) | 24hr ticker price change statistics | None | symbol, symbols, type, symbolStatus | No |


### PR DESCRIPTION
Both Spot and Futures historicalTrades endpoints are marked "Authentication: No" but they are MARKET_DATA security type requiring the X-MBX-APIKEY header. Agents calling these without the API key will receive 401 errors.