### PR TITLE
Add third-party domain warning to K-Line API in query-token-info

### DIFF
--- a/skills/binance-web3/query-token-info/SKILL.md
+++ b/skills/binance-web3/query-token-info/SKILL.md
@@ -348,6 +348,8 @@ curl --location 'https://web3.binance.com/bapi/defi/v4/public/wallet-direct/buw/
 https://dquery.sintral.io/u-kline/v1/k-line/candles
 ```
 
+> **Note:** This endpoint uses a third-party service (`dquery.sintral.io`), not the standard Binance Web3 API domain. Do not send Binance authentication headers to this endpoint.
+
 **Request Parameters**:
 
 | Parameter | Type | Required | Description |


### PR DESCRIPTION
The K-Line API endpoint uses dquery.sintral.io instead of web3.binance.com. Without a warning, developers may send Binance auth headers to a non-Binance domain, creating a credential exposure risk.