### PR TITLE
Document newClientOrderId length constraint with agent- prefix

### DIFF
--- a/skills/binance/derivatives-trading-usds-futures/SKILL.md
+++ b/skills/binance/derivatives-trading-usds-futures/SKILL.md
@@ -315,6 +315,8 @@ Otherwise, do not perform steps 3–5.
 
 For endpoints that include the `newClientOrderId` parameter, the value must always start with `agent-`. If the parameter is not provided, `agent-` followed by 18 random alphanumeric characters will be generated automatically. If a value is provided, it will be prefixed with `agent-`
 
+> **Important:** The `agent-` prefix (6 characters) counts toward the 36-character limit. User-provided values must not exceed 30 characters.
+
 Example: `agent-1a2b3c4d5e6f7g8h9i`
 
 ## User Agent Header

--- a/skills/binance/margin-trading/SKILL.md
+++ b/skills/binance/margin-trading/SKILL.md
@@ -288,6 +288,8 @@ Otherwise, do not perform steps 3–5.
 
 For endpoints that include the `newClientOrderId` parameter, the value must always start with `agent-`. If the parameter is not provided, `agent-` followed by 18 random alphanumeric characters will be generated automatically. If a value is provided, it will be prefixed with `agent-`
 
+> **Important:** The `agent-` prefix (6 characters) counts toward the 36-character limit. User-provided values must not exceed 30 characters.
+
 Example: `agent-1a2b3c4d5e6f7g8h9i`
 
 ## User Agent Header

--- a/skills/binance/spot/SKILL.md
+++ b/skills/binance/spot/SKILL.md
@@ -336,6 +336,8 @@ Otherwise, do not perform steps 3–5.
 
 For endpoints that include the `newClientOrderId` parameter, the value must always start with `agent-`. If the parameter is not provided, `agent-` followed by 18 random alphanumeric characters will be generated automatically. If a value is provided, it will be prefixed with `agent-`
 
+> **Important:** The `agent-` prefix (6 characters) counts toward the 36-character limit. User-provided values must not exceed 30 characters.
+
 Example: `agent-1a2b3c4d5e6f7g8h9i`
 
 ## User Agent Header


### PR DESCRIPTION
The agent- prefix (6 chars) counts toward the 36-character max for newClientOrderId, but this interaction is undocumented. IDs exceeding 30 chars + 6 char prefix = 36+ chars cause order rejection. Added warning to futures, spot, and margin trading skills.