### PR TITLE
Add missing NONE value to Futures selfTradePreventionMode enum

### DIFF
--- a/skills/binance/derivatives-trading-usds-futures/SKILL.md
+++ b/skills/binance/derivatives-trading-usds-futures/SKILL.md
@@ -188,7 +188,7 @@ Derivatives-trading-usds-futures request on Binance using authenticated API endp
 * **timeInForce**: GTC | IOC | FOK | GTX | GTD | RPI
 * **workingType**: MARK_PRICE | CONTRACT_PRICE
 * **newOrderRespType**: ACK | RESULT
-* **selfTradePreventionMode**: EXPIRE_TAKER | EXPIRE_BOTH | EXPIRE_MAKER
+* **selfTradePreventionMode**: NONE | EXPIRE_TAKER | EXPIRE_MAKER | EXPIRE_BOTH
 * **autoCloseType**: LIQUIDATION | ADL
 
 


### PR DESCRIPTION
Futures selfTradePreventionMode was missing NONE, which is present in the Spot skill. Without NONE, self-trade prevention cannot be disabled on futures orders.