### PR TITLE
Document safer API credential setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ npx skills add https://github.com/binance/binance-skills-hub
 
 ### Authentication
 
-For Binance Skills, certain endpoints require you to provide Binance API credentials. You can do this by setting environment variables, using a secrets file (such as `.env` or `.openclaw/secrets.env`) , or sending them directly to the agent in the chat. For more details, see the [Security](./skills/binance/spot/SKILL.md#security) section in each skill.
+Certain Binance Skill endpoints require API credentials. Provide them through environment variables
+or a supported local secrets file, such as `.env` or `.openclaw/secrets.env`. Do not paste API
+secrets into chat or commit them to version control. For more details, see the
+[Binance authentication security rules](./skills/binance/binance/references/auth.md#security-rules).
 
 ---
 


### PR DESCRIPTION
## Summary

- remove the suggestion to paste Binance API credentials into agent chat
- direct users to environment variables or supported local secrets files
- replace the broken Spot security link with the current authentication security rules

## Verification

- confirmed the authentication reference and `#security-rules` heading exist
- `git diff --check`