### PR TITLE
Add aiko: multi-signal decision-fusion skill

### DIFF
--- a/skills/binance-web3/aiko/CHANGELOG.md
+++ b/skills/binance-web3/aiko/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 - 2026-08-20
+
+- Initial release: `decide` command fusing `trading-signal` momentum, `crypto-market-rank` flow,
+  and `query-token-audit` risk into one composite decision, confidence score, and rationale.
+- Risk veto: `riskLevel >= 4` or tax > 10% forces `AVOID` regardless of other inputs.
+- No network calls, no credentials — pure scoring over caller-supplied data.

--- a/skills/binance-web3/aiko/LICENSE.md
+++ b/skills/binance-web3/aiko/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2026 0xMerl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/skills/binance-web3/aiko/SKILL.md
+++ b/skills/binance-web3/aiko/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: aiko
+description: |
+  Multi-signal decision-fusion engine for a single token: combines trading-signal momentum,
+  crypto-market-rank flow/leaderboard position, and query-token-audit risk into one composite
+  decision (LEAN_BUY / NEUTRAL / LEAN_SELL / AVOID) with a confidence score and full rationale.
+  Aiko reasons over data that sibling skills fetch — it makes no network calls itself, holds no
+  credentials, and never executes a trade.
+  Use for: "what does Aiko think about $X", "give me one decision from these signals",
+  "synthesize the audit and the trading signal", "risk-weighted read on this token",
+  "combine momentum, flow, and risk into a call", "should this even be on my radar".
+version: 0.1.0
+license: MIT
+metadata:
+  author: 0xMerl
+---
+
+# Aiko Skill
+
+## Overview
+
+Aiko is a **decision-fusion layer**, not a data source. It takes signals already fetched from
+other installed skills — [`trading-signal`](../trading-signal/SKILL.md) (momentum),
+[`crypto-market-rank`](../crypto-market-rank/SKILL.md) (flow / leaderboard position), and
+[`query-token-audit`](../query-token-audit/SKILL.md) (risk) — and reduces them to a single
+composite score, a decision bucket, a confidence level, and a plain-language rationale.
+
+It exists because those three skills each answer a narrow question ("is smart money buying?",
+"is this trending?", "is the contract dangerous?") and a user asking "what do you think about
+this token" needs those combined and weighed against each other, not three separate reports.
+
+**Aiko's own script performs no HTTP calls and requires no API keys or wallet connection.**
+All network access happens through the sibling skills listed above; Aiko only does the scoring
+arithmetic. See [`references/orchestration.md`](references/orchestration.md) for how to gather
+those inputs step by step.
+
+## When to Use This Skill
+
+| User intent | Command |
+|--------------|---------|
+| Fuse momentum + flow + risk signals for one token into a single decision | `decide` |
+
+## How to Call
+
+```bash
+node <skill-dir>/scripts/cli.mjs decide '<json_input>'
+```
+
+`<json_input>` is an object with up to three optional keys — `signal` (from `trading-signal`),
+`rank` (from `crypto-market-rank`), and `audit` (from `query-token-audit`). Any key you omit is
+treated as "no data available" and scored neutrally rather than guessed at. Full field-level
+schema, worked examples, and the exact scoring formula are in
+[`references/cli.md`](references/cli.md).
+
+## Decision Buckets
+
+| Bucket | Meaning |
+|--------|---------|
+| `LEAN_BUY` | Composite score ≥ 70, no risk veto, momentum not bearish |
+| `NEUTRAL` | Composite score 45–69, or signals conflict, or too little data |
+| `LEAN_SELL` | Composite score < 45 and momentum not bullish |
+| `AVOID` | Risk veto triggered (see below) — overrides every other input |
+
+These labels are deliberately hedged (`LEAN_*`, not `BUY`/`SELL`) — see Trading Rules below.
+
+## Risk Veto
+
+If `query-token-audit` reports `riskLevel >= 4`, or buy/sell tax over 10%, Aiko forces `AVOID`
+regardless of how bullish the momentum or flow signals are. A missing or unavailable audit is
+scored as elevated risk (30/100), never as neutral — absence of a red flag is not the same as a
+green one. This mirrors the audit-gating behavior already required of
+[`binance-agentic-wallet`](../binance-agentic-wallet/references/security.md) before any swap.
+
+## Confidence
+
+Confidence reflects how many of the three signal sources were actually available, not how
+strong the composite score is — a unanimous `LEAN_BUY` built from one data source is reported as
+low-confidence. Always surface the confidence number alongside the decision; do not present a
+low-confidence decision with the same weight as a high-confidence one.
+
+## Execution Boundary — read before doing anything else
+
+Aiko produces a **recommendation object only**. It never places an order, never calls a
+state-changing endpoint, and never should be wired to do so silently.
+
+- If the user wants to act on Aiko's decision, hand off to
+  [`binance-agentic-wallet`](../binance-agentic-wallet/SKILL.md) or the
+  [`binance`](../../binance/binance/SKILL.md) trading skill, and follow **that skill's own**
+  confirmation rules in full — do not shortcut them because Aiko already "decided."
+  `binance-agentic-wallet` requires explicit user confirmation before every state-changing
+  command; that requirement is not optional and Aiko does not change it.
+- Do **not** build a loop that reads Aiko's `decision` field and calls a trading skill
+  automatically without a human in the middle. If a user explicitly wants that kind of
+  unattended automation, read
+  [`references/autonomous-mode.md`](references/autonomous-mode.md) first — it lays out why the
+  default flow requires confirmation and what a user would need to build (and accept
+  responsibility for) themselves to remove it.
+
+## Trading Rules
+
+Per the hub's contribution rules, Aiko's output must stay neutral, factual, and educational:
+
+- Never rephrase a `LEAN_BUY`/`LEAN_SELL` bucket as a guarantee or promotion of the asset.
+- Always include the disclaimer field from the script's output verbatim; do not shorten it away.
+- Never fabricate a value for a signal that wasn't supplied — report it as unavailable and let
+  that lower the confidence score instead.
+
+## Full Reference
+
+- [`references/orchestration.md`](references/orchestration.md) — step-by-step: which sibling
+  skill to call for each input, and what to do when one isn't installed.
+- [`references/cli.md`](references/cli.md) — full input/output schema, scoring formula, and
+  worked examples.
+- [`references/autonomous-mode.md`](references/autonomous-mode.md) — why unattended execution is
+  out of scope by default, and the safeguards a user would need to add if they build it anyway.

--- a/skills/binance-web3/aiko/references/autonomous-mode.md
+++ b/skills/binance-web3/aiko/references/autonomous-mode.md
@@ -1,0 +1,43 @@
+# Why Aiko Doesn't Trade By Itself
+
+Aiko's `decide` command is deliberately a pure, read-only calculation with no side effects. This
+is not a missing feature — it's a boundary kept on purpose, for reasons worth stating explicitly
+since "an agent that decides on its own" is exactly what Aiko was asked to be.
+
+## Why the default has no autonomous execution path
+
+- **Every other trading-capable skill in this hub requires human confirmation before a
+  state-changing call.** `binance-agentic-wallet` states it plainly: "Confirm before execution.
+  Confirm with the user each time before any state-changing command." Aiko wiring itself around
+  that check — even indirectly, by calling `baw` in a loop keyed off its own `decision` field —
+  would defeat a safeguard that exists for a reason: real funds move, and a wrong call is not
+  reversible.
+- **Skills in this hub run with full agent permissions on whatever machine installs them.** A
+  published skill that fires trades unattended is something a stranger could install and walk
+  away from, not just something its author runs carefully. The blast radius of a mistake (a bad
+  composite score, a stale audit, an upstream API hiccup) is somebody else's money, not a bug
+  report.
+- **The hub's own trading rules require output to stay neutral, factual, and educational** — an
+  autonomous executor is, by construction, no longer just informational.
+
+## If you still want this
+
+Aiko's `decide` output is plain JSON specifically so it *can* be consumed by something else. If
+you build a personal automation on top of it, that automation is your code, running with your
+API keys, under your judgment — not a feature of this skill. At minimum:
+
+- **Default to dry-run.** Log what it *would* have done before ever letting it place a real
+  order.
+- **Use a trade-only API key with withdrawals disabled**, scoped to the smallest permission set
+  that works.
+- **Hard-cap position size and daily loss**, enforced in code, not just as a setting you trust
+  yourself to respect.
+- **Require `riskVeto: false` and a minimum `confidence`** before acting on any decision — never
+  act on a low-confidence read just because the bucket happened to be `LEAN_BUY`.
+- **Keep a kill switch and an audit log** you actually check.
+- **Never remove the confirmation step from `binance-agentic-wallet` itself** — build your
+  automation to call it the same way a human-directed session would, so the same safety checks
+  (audit pre-check, slippage disclosure, etc.) still run.
+
+None of the above is enforced by Aiko or by this hub. It's the minimum a reasonable person would
+want in place before letting code they wrote spend real money without asking first.

--- a/skills/binance-web3/aiko/references/cli.md
+++ b/skills/binance-web3/aiko/references/cli.md
@@ -1,0 +1,86 @@
+# CLI Reference
+
+## `decide`
+
+```bash
+node scripts/cli.mjs decide '<json_input>'
+```
+
+### Input Schema
+
+All top-level keys are optional. Omit a key entirely when that data isn't available — do not
+pass `null` placeholders or invented values.
+
+| Key | Shape | Source |
+|-----|-------|--------|
+| `signal` | `{ direction: "buy"\|"sell", status: "active"\|"timeout"\|"completed", exitRate: number, smartMoneyCount: number }` | `trading-signal` `smart-money` |
+| `rank` | `{ position: number, totalRanked: number }` | `crypto-market-rank` `smart-money-inflow` / `token-rank` |
+| `audit` | Raw `data` object from the audit response (`hasResult`, `isSupported`, `riskLevel`, `riskLevelEnum`, `extraInfo.buyTax`, `extraInfo.sellTax`, `extraInfo.isVerified`) | `query-token-audit` |
+| `weights` | `{ momentum?: number, flow?: number, risk?: number }`, default `{0.35, 0.25, 0.40}` | caller override, must sum to ~1.0 |
+
+### Output Schema
+
+```json
+{
+  "decision": "LEAN_BUY | NEUTRAL | LEAN_SELL | AVOID",
+  "compositeScore": 0,
+  "confidence": 20,
+  "subscores": { "momentum": 0, "flow": 0, "risk": 0 },
+  "rationale": ["...", "...", "..."],
+  "riskVeto": false,
+  "generatedAt": "ISO-8601 timestamp",
+  "disclaimer": "..."
+}
+```
+
+- `confidence` (20–80) scales with how many of `signal` / `rank` / an *available* `audit` were
+  supplied — 20 with zero, up to 80 with all three. It never reaches 100; Aiko's inputs are
+  themselves point-in-time snapshots from upstream skills, and confidence reflects that.
+- `riskVeto: true` means `decision` is forced to `AVOID` regardless of `compositeScore`.
+- Always print `disclaimer` verbatim alongside the decision.
+
+### Scoring Formula (informative — see `scripts/cli.mjs` for the source of truth)
+
+- **Momentum** (0–100): starts at 50; `+20` for `direction: "buy"`, `-20` for `"sell"`; `+10` /
+  `-10` / `-5` for `status` active/timeout/completed; subtracts up to 25 as `exitRate` rises
+  (high exit rate ⇒ opportunity likely already matured); adds up to 20 for `smartMoneyCount`
+  (more independent wallets ⇒ more reliable signal).
+- **Flow** (0–100): percentile of `position` within `totalRanked` — higher percentile (closer to
+  #1) scores higher.
+- **Risk** (0–100, inverted): `riskLevel` 0–1 → 85–95, 2–3 → 50–65, 4 → 15, 5 → 0. Capped at 40
+  if unverified, capped at 40 if tax 5–10%, capped at 10 if tax > 10%. Missing/unavailable audit
+  scores 30 (elevated, not neutral).
+- **Composite** = weighted sum of the three subscores using `weights` (default 35/25/40 —
+  risk weighted highest by design).
+- **Bucket**: `riskVeto` → `AVOID`; zero input sources supplied → `NEUTRAL` (a composite pulled
+  only by the risk score's conservative "unavailable" default is a statement about missing data,
+  not a bearish read); else composite ≥ 70 → `LEAN_BUY` (or `NEUTRAL` if momentum direction is
+  `"sell"`); composite < 45 → `LEAN_SELL` (or `NEUTRAL` if momentum direction is `"buy"`);
+  otherwise `NEUTRAL`.
+
+### Example
+
+```bash
+node scripts/cli.mjs decide '{
+  "signal": {"direction":"buy","status":"active","exitRate":12,"smartMoneyCount":6},
+  "rank": {"position":8,"totalRanked":200},
+  "audit": {"hasResult":true,"isSupported":true,"riskLevel":1,"riskLevelEnum":"LOW","extraInfo":{"buyTax":"0","sellTax":"0","isVerified":true}}
+}'
+```
+
+```json
+{
+  "decision": "LEAN_BUY",
+  "compositeScore": 73,
+  "confidence": 80,
+  "subscores": { "momentum": 78, "flow": 96, "risk": 61 },
+  "rationale": [
+    "direction=buy status=active exitRate=12% smartMoneyCount=6",
+    "rank 8/200",
+    "riskLevel=LOW buyTax=0% sellTax=0%"
+  ],
+  "riskVeto": false,
+  "generatedAt": "2026-08-20T00:00:00.000Z",
+  "disclaimer": "Informational only — not investment, financial, or trading advice. Aiko does not execute trades; any action requires a separate, explicitly confirmed step in the appropriate skill (e.g. binance-agentic-wallet). DYOR."
+}
+```

--- a/skills/binance-web3/aiko/references/orchestration.md
+++ b/skills/binance-web3/aiko/references/orchestration.md
@@ -1,0 +1,52 @@
+# Orchestration
+
+Aiko has no data of its own. Before calling `decide`, gather up to three inputs by calling
+sibling skills. Skip any you can't get — do not guess a value to fill a gap.
+
+## 1. Momentum → `signal`
+
+Call the `trading-signal` skill's `smart-money` command for the token's chain:
+
+```bash
+node <trading-signal-dir>/scripts/cli.mjs smart-money '{"chainId":"56","page":1,"pageSize":50}'
+```
+
+Find the entry for your target token and pass through `direction`, `status`, `exitRate`, and
+`smartMoneyCount` as the `signal` object. If the token has no active smart-money signal, omit
+`signal` entirely rather than inventing neutral-looking values.
+
+## 2. Flow → `rank`
+
+Call `crypto-market-rank`'s `smart-money-inflow` or `token-rank` command for the same chain:
+
+```bash
+node <crypto-market-rank-dir>/scripts/cli.mjs smart-money-inflow '{"chainId":"56","period":"24h"}'
+```
+
+Find the token's position in the returned list and the list's total length, and pass
+`{"position": N, "totalRanked": M}` as `rank`. If the token doesn't appear in the ranked list at
+all, omit `rank` — don't assume last place.
+
+## 3. Risk → `audit`
+
+Call `query-token-audit`:
+
+```bash
+node <query-token-audit-dir>/scripts/cli.mjs audit '{"binanceChainId":"56","contractAddress":"0x...","requestId":"<uuid>"}'
+```
+
+Pass the full response `data` object through as `audit` unchanged (Aiko reads `hasResult`,
+`isSupported`, `riskLevel`, `riskLevelEnum`, and `extraInfo.buyTax`/`sellTax` directly). If the
+`query-token-audit` skill isn't installed, tell the user: "The token audit skill is not
+installed. Install it from https://github.com/binance/binance-skills-hub for a risk-aware
+decision — without it, Aiko treats risk as unknown and elevated." Then call `decide` with
+`audit` omitted; do not block on installation.
+
+## 4. Assemble and call
+
+```bash
+node <aiko-dir>/scripts/cli.mjs decide '{"signal": {...}, "rank": {...}, "audit": {...}}'
+```
+
+Any of the three top-level keys may be omitted. Present the result to the user per
+[`cli.md`](cli.md)'s output schema, including the disclaimer field verbatim.

--- a/skills/binance-web3/aiko/scripts/cli.mjs
+++ b/skills/binance-web3/aiko/scripts/cli.mjs
@@ -7,7 +7,23 @@
 // Usage: node cli.mjs decide '<json_input>'
 // See references/cli.md for the full input/output schema and scoring formula.
 
+import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+
+// Same guard used by binance-sports-ai-analyzer's cli.mjs: compares resolved
+// filesystem paths (via realpathSync, which also collapses the symlinks the
+// `skills add` installer creates) rather than raw URL strings, since
+// `import.meta.url === \`file://${process.argv[1]}\`` never matches on
+// Windows (file:// URLs there use forward slashes and a /drive: prefix that
+// never string-equals argv[1]'s OS-native backslash path).
+function isDirectExecution() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+}
 
 const CLAMP = (n, lo, hi) => Math.min(hi, Math.max(lo, n));
 
@@ -101,10 +117,7 @@ function computeDecision(input = {}) {
 export { computeDecision, scoreMomentum, scoreFlow, scoreRisk, DEFAULT_WEIGHTS };
 
 // ---- CLI dispatch (only runs when executed directly, not when imported) ----
-// Compares resolved filesystem paths rather than raw URL strings so this works
-// on Windows too (file:// URLs there use forward slashes and a /drive: prefix
-// that never string-equals `file://${argv[1]}`, which uses OS-native backslashes).
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+if (isDirectExecution()) {
   const [cmd, paramsStr] = process.argv.slice(2);
 
   if (!cmd || cmd === '--help' || cmd === '-h') {

--- a/skills/binance-web3/aiko/scripts/cli.mjs
+++ b/skills/binance-web3/aiko/scripts/cli.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Aiko decision-scoring engine — self-contained, zero-dep, Node >= 22.
+// Pure function: takes already-fetched signal data from sibling skills and
+// returns one composite decision. Aiko makes NO network calls and holds NO
+// credentials or wallet access — it only reasons over data the caller supplies.
+//
+// Usage: node cli.mjs decide '<json_input>'
+// See references/cli.md for the full input/output schema and scoring formula.
+
+import { fileURLToPath } from 'node:url';
+
+const CLAMP = (n, lo, hi) => Math.min(hi, Math.max(lo, n));
+
+const DEFAULT_WEIGHTS = { momentum: 0.35, flow: 0.25, risk: 0.40 };
+
+function scoreMomentum(signal) {
+  if (!signal) return { score: 50, note: 'no trading-signal data supplied' };
+  const { direction, status, exitRate, smartMoneyCount = 0 } = signal;
+  let score = 50;
+  if (direction === 'buy') score += 20;
+  if (direction === 'sell') score -= 20;
+  if (status === 'active') score += 10;
+  if (status === 'timeout') score -= 10;
+  if (status === 'completed') score -= 5;
+  const exit = Number(exitRate) || 0;
+  score -= CLAMP(exit / 2, 0, 25);
+  score += CLAMP(Number(smartMoneyCount) || 0, 0, 20);
+  return {
+    score: CLAMP(score, 0, 100),
+    note: `direction=${direction ?? 'n/a'} status=${status ?? 'n/a'} exitRate=${exit}% smartMoneyCount=${smartMoneyCount}`,
+  };
+}
+
+function scoreFlow(rank) {
+  if (!rank || rank.position == null || !rank.totalRanked) {
+    return { score: 50, note: 'no rank data supplied' };
+  }
+  const percentile = 1 - (rank.position - 1) / rank.totalRanked;
+  return { score: CLAMP(percentile * 100, 0, 100), note: `rank ${rank.position}/${rank.totalRanked}` };
+}
+
+function scoreRisk(audit) {
+  if (!audit || audit.hasResult === false || audit.isSupported === false) {
+    return { score: 30, veto: false, note: 'audit unavailable — treated as elevated risk, not verified safe' };
+  }
+  const level = Number(audit.riskLevel);
+  const table = { 0: 95, 1: 85, 2: 65, 3: 50, 4: 15, 5: 0 };
+  let score = table[level] ?? 50;
+  const buyTax = Number(audit?.extraInfo?.buyTax) || 0;
+  const sellTax = Number(audit?.extraInfo?.sellTax) || 0;
+  if (buyTax > 10 || sellTax > 10) score = Math.min(score, 10);
+  else if (buyTax > 5 || sellTax > 5) score = Math.min(score, 40);
+  if (audit?.extraInfo?.isVerified === false) score = Math.min(score, 40);
+  const veto = level >= 4 || buyTax > 10 || sellTax > 10;
+  return {
+    score: CLAMP(score, 0, 100),
+    veto,
+    note: `riskLevel=${audit.riskLevelEnum ?? level} buyTax=${buyTax}% sellTax=${sellTax}%`,
+  };
+}
+
+function bucket(composite, momentumDir, veto, sourcesAvailable) {
+  if (veto) return 'AVOID';
+  // With zero real inputs, the composite is pulled entirely by scoreRisk's
+  // conservative "unavailable" default — that's a statement about missing
+  // data, not a bearish read. Don't let it masquerade as a leaning decision.
+  if (sourcesAvailable === 0) return 'NEUTRAL';
+  if (composite >= 70) return momentumDir === 'sell' ? 'NEUTRAL' : 'LEAN_BUY';
+  if (composite < 45) return momentumDir === 'buy' ? 'NEUTRAL' : 'LEAN_SELL';
+  return 'NEUTRAL';
+}
+
+function computeDecision(input = {}) {
+  const { signal, rank, audit, weights = {} } = input;
+  const w = { ...DEFAULT_WEIGHTS, ...weights };
+  const m = scoreMomentum(signal);
+  const f = scoreFlow(rank);
+  const r = scoreRisk(audit);
+
+  const composite = m.score * w.momentum + f.score * w.flow + r.score * w.risk;
+
+  const auditAvailable = audit && audit.hasResult !== false && audit.isSupported !== false;
+  const sourcesAvailable = [signal, rank, auditAvailable ? audit : null].filter(Boolean).length;
+  const decision = bucket(composite, signal?.direction, r.veto, sourcesAvailable);
+  const confidence = CLAMP(20 + sourcesAvailable * 20, 20, 80);
+
+  return {
+    decision,
+    compositeScore: Math.round(composite),
+    confidence,
+    subscores: { momentum: Math.round(m.score), flow: Math.round(f.score), risk: Math.round(r.score) },
+    rationale: [m.note, f.note, r.note],
+    riskVeto: r.veto,
+    generatedAt: new Date().toISOString(),
+    disclaimer:
+      'Informational only — not investment, financial, or trading advice. Aiko does not execute trades; any action requires a separate, explicitly confirmed step in the appropriate skill (e.g. binance-agentic-wallet). DYOR.',
+  };
+}
+
+// ---- exports (for unit testing; direct execution still works — see dispatch below) ----
+export { computeDecision, scoreMomentum, scoreFlow, scoreRisk, DEFAULT_WEIGHTS };
+
+// ---- CLI dispatch (only runs when executed directly, not when imported) ----
+// Compares resolved filesystem paths rather than raw URL strings so this works
+// on Windows too (file:// URLs there use forward slashes and a /drive: prefix
+// that never string-equals `file://${argv[1]}`, which uses OS-native backslashes).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const [cmd, paramsStr] = process.argv.slice(2);
+
+  if (!cmd || cmd === '--help' || cmd === '-h') {
+    console.log("Usage: node cli.mjs decide '<json_input>'\n\nSee references/cli.md for the input/output schema.");
+    process.exit(0);
+  }
+
+  if (cmd !== 'decide') {
+    console.error(`Unknown command: ${cmd}\nOnly "decide" is supported.`);
+    process.exit(1);
+  }
+
+  let input = {};
+  if (paramsStr) {
+    try { input = JSON.parse(paramsStr); }
+    catch { console.error('Invalid JSON params'); process.exit(1); }
+  }
+
+  console.log(JSON.stringify(computeDecision(input), null, 2));
+}


### PR DESCRIPTION
# Summary

Adds `aiko`, a decision-fusion skill that combines momentum (`trading-signal`), flow/leaderboard
position (`crypto-market-rank`), and risk (`query-token-audit`) into one composite decision
(`LEAN_BUY` / `NEUTRAL` / `LEAN_SELL` / `AVOID`) with a confidence score and rationale, instead of
a user having to read three separate skill outputs and weigh them manually themselves.

# APIs Used

None. Aiko makes no HTTP calls and holds no credentials — it's a pure scoring function over JSON
already fetched by sibling skills. See `references/orchestration.md` for which sibling skill
supplies each input field.

# Binaries Used

`node` (>= 22) — same runtime as the rest of the hub's skills, no external packages.

# How it works

`scripts/cli.mjs decide '<json>'` takes up to three optional inputs (`signal`, `rank`, `audit`),
each mapped 1:1 to a field shape already returned by an existing skill (see
`references/cli.md` for the schema). Each input is scored independently 0–100, then combined into
a weighted composite (risk weighted highest, 40%, by design). A hard risk veto (audit
`riskLevel >= 4` or tax > 10%) forces `AVOID` regardless of composite score. Missing inputs are
scored neutrally/conservatively rather than guessed, and confidence scales down with how many of
the three sources were actually supplied — a decision built from one data point is flagged as
low-confidence rather than presented with the same weight as a fully-sourced one.

Aiko never executes a trade. `references/autonomous-mode.md` documents why that boundary is
deliberate (every other trading-capable skill in this hub requires human confirmation before a
state-changing call) and what a user would need to build themselves, at their own risk, if they
want to wire Aiko's output into unattended automation.

# Use Cases

- "What does Aiko think about $X?" — one synthesized read instead of three separate skill calls.
- Pre-trade sanity check before handing off to `binance-agentic-wallet`: surface the risk veto
  before a user gets excited about a momentum signal on an unaudited/high-risk contract.
- Programmatic consumers that want one structured decision object (with explicit confidence and
  rationale) rather than parsing and reconciling three different skills' raw responses themselves.
