### PR TITLE
Fix CLI scripts producing no output on Windows

### DIFF
--- a/skills/binance-web3/binance-trading-signal/scripts/cli.mjs
+++ b/skills/binance-web3/binance-trading-signal/scripts/cli.mjs
@@ -5,6 +5,23 @@
 // Commands:
 //   smart-money  POST  on-chain Smart Money trading signals (BSC + Solana)
 
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Compares resolved filesystem paths (via realpathSync, which also collapses
+// the symlinks the `skills add` installer creates) rather than raw URL
+// strings, since `import.meta.url === \`file://${process.argv[1]}\`` never
+// matches on Windows (file:// URLs there use forward slashes and a /drive:
+// prefix that never string-equals argv[1]'s OS-native backslash path).
+function isDirectExecution() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+}
+
 // ---- inline HTTP helper (self-contained, zero dependency) ----
 const TIMEOUT_MS = 10_000;
 const UA = { 'Accept-Encoding': 'identity', 'User-Agent': 'binance-web3/2.0 (Skill)' };
@@ -62,7 +79,7 @@ const COMMANDS = {
 export { COMMANDS, call, qs, UA, TIMEOUT_MS, CHAINS, validateChainId };
 
 // ---- CLI dispatch (only runs when executed directly, not when imported) ----
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectExecution()) {
   const [cmd, paramsStr] = process.argv.slice(2);
 
   if (!cmd || cmd === '--help' || cmd === '-h') {

--- a/skills/binance-web3/crypto-market-rank/scripts/cli.mjs
+++ b/skills/binance-web3/crypto-market-rank/scripts/cli.mjs
@@ -10,6 +10,23 @@
 //   address-pnl-rank    GET   top trader PnL leaderboard
 //
 
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Compares resolved filesystem paths (via realpathSync, which also collapses
+// the symlinks the `skills add` installer creates) rather than raw URL
+// strings, since `import.meta.url === \`file://${process.argv[1]}\`` never
+// matches on Windows (file:// URLs there use forward slashes and a /drive:
+// prefix that never string-equals argv[1]'s OS-native backslash path).
+function isDirectExecution() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+}
+
 // ---- inline HTTP helper (self-contained, zero dependency) ----
 const TIMEOUT_MS = 10_000;
 const UA = { 'Accept-Encoding': 'identity', 'User-Agent': 'binance-web3/3.0 (Skill)' };
@@ -119,7 +136,7 @@ const COMMANDS = {
 export { COMMANDS, call, qs, UA, TIMEOUT_MS, CHAINS, validateChainId };
 
 // ---- CLI dispatch (only runs when executed directly, not when imported) ----
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectExecution()) {
   const [cmd, paramsStr] = process.argv.slice(2);
 
   if (!cmd || cmd === '--help' || cmd === '-h') {

--- a/skills/binance-web3/meme-rush/scripts/cli.mjs
+++ b/skills/binance-web3/meme-rush/scripts/cli.mjs
@@ -7,6 +7,23 @@
 //   topic-rush  GET   AI-powered hot-topic discovery with associated tokens
 //
 
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Compares resolved filesystem paths (via realpathSync, which also collapses
+// the symlinks the `skills add` installer creates) rather than raw URL
+// strings, since `import.meta.url === \`file://${process.argv[1]}\`` never
+// matches on Windows (file:// URLs there use forward slashes and a /drive:
+// prefix that never string-equals argv[1]'s OS-native backslash path).
+function isDirectExecution() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+}
+
 // ---- inline HTTP helper (self-contained, zero dependency) ----
 const TIMEOUT_MS = 10_000;
 const UA = { 'Accept-Encoding': 'identity', 'User-Agent': 'binance-web3/2.0 (Skill)' };
@@ -71,7 +88,7 @@ const COMMANDS = {
 export { COMMANDS, call, qs, UA, TIMEOUT_MS, CHAINS, validateChainId };
 
 // ---- CLI dispatch (only runs when executed directly, not when imported) ----
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectExecution()) {
   const [cmd, paramsStr] = process.argv.slice(2);
 
   if (!cmd || cmd === '--help' || cmd === '-h') {

--- a/skills/binance-web3/query-address-info/scripts/cli.mjs
+++ b/skills/binance-web3/query-address-info/scripts/cli.mjs
@@ -6,6 +6,23 @@
 //   positions  GET  wallet active-position list (token balances + 24h price change)
 //
 
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Compares resolved filesystem paths (via realpathSync, which also collapses
+// the symlinks the `skills add` installer creates) rather than raw URL
+// strings, since `import.meta.url === \`file://${process.argv[1]}\`` never
+// matches on Windows (file:// URLs there use forward slashes and a /drive:
+// prefix that never string-equals argv[1]'s OS-native backslash path).
+function isDirectExecution() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+}
+
 // ---- inline HTTP helper (self-contained, zero dependency) ----
 const TIMEOUT_MS = 10_000;
 const UA = { 'Accept-Encoding': 'identity', 'User-Agent': 'binance-web3/2.0 (Skill)' };
@@ -102,7 +119,7 @@ const COMMANDS = {
 export { COMMANDS, call, qs, UA, TIMEOUT_MS, validateAddress, validateChainId, SUPPORTED_CHAINS };
 
 // ---- CLI dispatch (only runs when executed directly, not when imported) ----
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectExecution()) {
   const [cmd, paramsStr] = process.argv.slice(2);
 
   if (!cmd || cmd === '--help' || cmd === '-h') {

--- a/skills/binance-web3/query-token-info/scripts/cli.mjs
+++ b/skills/binance-web3/query-token-info/scripts/cli.mjs
@@ -13,6 +13,23 @@
 // (platform/address) — this CLI handles the translation so the LLM caller sees
 // one consistent interface.
 
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Compares resolved filesystem paths (via realpathSync, which also collapses
+// the symlinks the `skills add` installer creates) rather than raw URL
+// strings, since `import.meta.url === \`file://${process.argv[1]}\`` never
+// matches on Windows (file:// URLs there use forward slashes and a /drive:
+// prefix that never string-equals argv[1]'s OS-native backslash path).
+function isDirectExecution() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+}
+
 // ---- inline HTTP helper (self-contained, zero dependency) ----
 const TIMEOUT_MS = 10_000;
 const UA = { 'Accept-Encoding': 'identity', 'User-Agent': 'binance-web3/2.0 (Skill)' };
@@ -82,7 +99,7 @@ const COMMANDS = {
 export { COMMANDS, call, qs, UA, TIMEOUT_MS, CHAIN_ID_TO_PLATFORM };
 
 // ---- CLI dispatch (only runs when executed directly, not when imported) ----
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectExecution()) {
   const [cmd, paramsStr] = process.argv.slice(2);
 
   if (!cmd || cmd === '--help' || cmd === '-h') {

--- a/skills/binance-web3/trading-signal/scripts/cli.mjs
+++ b/skills/binance-web3/trading-signal/scripts/cli.mjs
@@ -5,6 +5,23 @@
 // Commands:
 //   smart-money  POST  on-chain Smart Money trading signals (BSC + Solana)
 
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Compares resolved filesystem paths (via realpathSync, which also collapses
+// the symlinks the `skills add` installer creates) rather than raw URL
+// strings, since `import.meta.url === \`file://${process.argv[1]}\`` never
+// matches on Windows (file:// URLs there use forward slashes and a /drive:
+// prefix that never string-equals argv[1]'s OS-native backslash path).
+function isDirectExecution() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+}
+
 // ---- inline HTTP helper (self-contained, zero dependency) ----
 const TIMEOUT_MS = 10_000;
 const UA = { 'Accept-Encoding': 'identity', 'User-Agent': 'binance-web3/2.0 (Skill)' };
@@ -62,7 +79,7 @@ const COMMANDS = {
 export { COMMANDS, call, qs, UA, TIMEOUT_MS, CHAINS, validateChainId };
 
 // ---- CLI dispatch (only runs when executed directly, not when imported) ----
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectExecution()) {
   const [cmd, paramsStr] = process.argv.slice(2);
 
   if (!cmd || cmd === '--help' || cmd === '-h') {


### PR DESCRIPTION
# Summary

Fixes a bug where 6 of this repo's `scripts/cli.mjs` files silently produce **zero output** on
Windows for every command, including `--help` — exit code 0, no stdout, no stderr, nothing.

# Root Cause

The CLI dispatch guard used across these scripts is:

```js
if (import.meta.url === `file://${process.argv[1]}`) { ... }
```

On Windows this never evaluates true: `import.meta.url` resolves to a URL like
`file:///D:/path/to/cli.mjs` (forward slashes, `/drive:` prefix), while `process.argv[1]` is an
OS-native path like `D:\path\to\cli.mjs` (backslashes). String-concatenating the latter into a
`file://` template never equals the former, so the guard is always false, the dispatch block
never runs, and the script exits 0 having done nothing — no error, so the failure is silent.

This is easy to miss in review/CI if those only run on Linux/macOS, where `argv[1]` happens to
already be a `/`-separated absolute path and the naive comparison accidentally works.

One script in the repo, `binance-sports-ai-analyzer/scripts/cli.mjs`, already avoids this by
comparing resolved filesystem paths instead of raw strings. This PR brings the other 6 scripts
in line with that same pattern for consistency, rather than introducing a second fix style.

# Binaries Used

`node` (>= 22) only — no new dependencies.

# How it works

Replaces the raw string comparison with:

```js
function isDirectExecution() {
  if (!process.argv[1]) return false;
  try {
    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
  } catch {
    return false;
  }
}
```

`fileURLToPath` normalizes `import.meta.url` back to an OS-native path first, and `realpathSync`
resolves both sides through any symlinks — which matters here specifically because the `skills
add` installer symlinks skill files (e.g. into `.agents/skills/...`) rather than copying them, so
`process.argv[1]` at runtime is frequently a symlink path.

# Affected Files

- `skills/binance-web3/trading-signal/scripts/cli.mjs`
- `skills/binance-web3/binance-trading-signal/scripts/cli.mjs`
- `skills/binance-web3/query-token-info/scripts/cli.mjs`
- `skills/binance-web3/query-address-info/scripts/cli.mjs`
- `skills/binance-web3/meme-rush/scripts/cli.mjs`
- `skills/binance-web3/crypto-market-rank/scripts/cli.mjs`

# Verification

On Windows, for each of the 6 files above:
- `node scripts/cli.mjs --help` now prints the usage/commands list (previously: nothing).
- `node scripts/cli.mjs <unknown-command> '{}'` prints the expected error and exits 1.
- `node scripts/cli.mjs <command> 'not-json'` prints `Invalid JSON params` and exits 1.
- `import('./scripts/cli.mjs')` still does not trigger CLI dispatch (confirms the guard isn't
  accidentally inverted).

No behavior changes on non-Windows platforms — `realpathSync`/`fileURLToPath` resolve to the
same effective comparison there, just implemented correctly instead of by string luck.
