### PR TITLE
Add onchain-pay-action-ref-verify skill

### DIFF
--- a/skills/binance/onchain-pay-action-ref-verify/SKILL.md
+++ b/skills/binance/onchain-pay-action-ref-verify/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: onchain-pay-action-ref-verify
+description: |
+  Derives and independently verifies action_ref — a deterministic,
+  content-addressed identifier (SHA-256 of RFC 8785 JCS canonicalization,
+  action-ref-v1 spec) — for a declared Onchain-Pay pre-order request/result
+  pair, and checks it against an on-chain anchor (AnchorRegistry,
+  permissionless anchor(bytes32)) if one exists. Read-only, no trading, no
+  order placement. Use when an agent or a downstream party needs an
+  externally checkable record of what a pre-order call declared and
+  returned, independent of the merchant account's own logs — e.g. "give me
+  a recomputable reference for this pre-order I just made" or "verify this
+  action_ref against the anchor."
+metadata:
+  version: "0.1.0"
+  author: giskard09
+license: MIT
+---
+
+# Onchain-Pay action_ref Verify
+
+Derives `action_ref` for a Binance Onchain-Pay `pre-order` request/result
+pair per [`action-ref-v1`](https://github.com/giskard09/argentum-core/blob/master/docs/spec/action-ref.md)
+(SHA-256 of the RFC 8785 JCS canonicalization of 4 fields: `agent_id`,
+`action_type`, `scope`, `timestamp`), and optionally verifies a claimed
+anchor against `AnchorRegistry` — a permissionless `anchor(bytes32)`
+contract deployed at the same CREATE2 address on Base, Arbitrum One, and
+Ink (`0x49fEcA52bC634a9Ab773226D16619deC547794aa`).
+
+## Why this exists
+
+Binance's own Agent OS launch coverage acknowledged a gap: asked how
+Binance assesses what caused a given agent trading action, Jeff Li told
+TechCrunch (2026-08-20), *"We really cannot see the reasoning of what the
+user's action is."*[^1] This skill does not answer *why* an action
+happened — that's a different, harder problem. It answers a narrower,
+adjacent one: given a declared `pre-order` request and its response, can
+any third party — not just the merchant, not just Binance — recompute a
+content-addressed identifier for that exact pair and confirm an
+independent, operator-external timestamp of when (if ever) it was
+anchored on a public chain? That's orthogonal to reasoning or intent, and
+this skill makes no claim to close that gap — only the separate one of
+externally-checkable record-keeping for a single Onchain-Pay call.
+
+[^1]: [TechCrunch, "Binance now lets AI agents trade, but keeping them in check is largely up to users," 2026-08-20](https://techcrunch.com/2026/08/20/binance-now-lets-ai-agents-trade-but-keeping-them-in-check-is-largely-up-to-users/).
+
+## Use Cases
+
+### 1. Derive a recomputable reference after a pre-order call
+
+**When to use**: after calling `buy/pre-order` (see
+[`skills/binance/onchain-pay/SKILL.md`](../onchain-pay/SKILL.md)), derive
+an `action_ref` from the declared request/response so any third party can
+independently confirm what was asked for and what came back.
+
+### 2. Verify a claimed anchor
+
+**When to use**: given an `action_ref` and a claimed anchor tx, confirm
+the `Anchored(bytes32,address,uint256)` event exists on-chain for that
+exact ref — without trusting the party that claims it.
+
+## How it works
+
+1. Build the 4-field preimage: `agent_id` (caller-declared), `action_type`
+   (`binance.onchain_pay.buy.pre_order`), `scope` (endpoint + network),
+   `timestamp` (RFC 3339 UTC, ms precision).
+2. `action_ref = SHA256(JCS(preimage))`.
+3. Also hash the full declared `params` (the pre-order request fields) and
+   `result` (the pre-order response — `data.link`, `data.linkExpireTime`)
+   as an additive envelope (`params_digest`, `result_digest`) — these do
+   not enter `action_ref` itself, they travel alongside it as
+   independently recomputable context.
+4. If an anchor is claimed, query `eth_getLogs` on the target chain for
+   `AnchorRegistry`'s `Anchored` event with `topics[1] == action_ref`.
+
+```bash
+# 1. derive action_ref + envelope from a request/response you actually have
+python3 scripts/produce.py '<request_json>' '<response_json>' \
+  --agent-id "<your-agent-id>" --timestamp "<RFC3339-UTC-ms>"
+
+# 2. check a claimed anchor against the chain (a block hint is required —
+#    public RPC rejects an unbounded eth_getLogs scan)
+python3 scripts/verify_anchor.py <action_ref> --chain base --near-block <N>
+```
+
+Both scripts are read-only, stdlib-only Python, and neither calls
+Binance's API — `produce.py` takes JSON you already have; `verify_anchor.py`
+queries public chain RPC directly.
+
+## Worked example
+
+A full, independently-reproducible instance — derivation, envelope, and a
+real on-chain anchor on Base mainnet — is published at
+[`giskard09/binance-onchain-pay-action-ref-anchor`](https://github.com/giskard09/binance-onchain-pay-action-ref-anchor).
+It is explicitly a **synthetic** worked example (see that repo's
+`PROVENANCE.md`): no real Binance merchant account, no real pre-order.
+Read it before using this skill against a real account.
+
+## Scope and limits
+
+- Read-only. No order placement, no trading, no wallet address collection.
+- Does not evaluate whether a pre-order's parameters are safe, favorable,
+  or advisable — only whether a declared request/result pair is
+  recomputable and (optionally) anchored.
+- Does not require any change to Binance's `onchain-pay` API or Binance's
+  participation. The anchor is written by whoever chooses to anchor it —
+  the merchant, the agent's operator, or a third party — using the
+  permissionless `AnchorRegistry` contract.
+
+## License
+
+MIT.

--- a/skills/binance/onchain-pay-action-ref-verify/scripts/produce.py
+++ b/skills/binance/onchain-pay-action-ref-verify/scripts/produce.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Derives action_ref (action-ref-v1: JCS RFC 8785 + SHA-256) for a declared
+Binance Onchain-Pay `pre-order` request/result pair, plus the additive
+params_digest/result_digest envelope.
+
+Does NOT call Binance's API and does NOT place any order. Takes the
+request and response JSON the caller already has (from its own pre-order
+call) and derives a recomputable identifier for them.
+
+Usage:
+    python3 produce.py '<request_json>' '<response_json>' [--agent-id ID] [--timestamp TS]
+
+<request_json>  — the pre-order request body actually sent (must include
+                   at minimum externalOrderId; other fields per
+                   skills/binance/onchain-pay/SKILL.md's pre-order table).
+<response_json> — the pre-order response actually received (per SKILL.md's
+                   documented response shape: code, message, success,
+                   data.link, data.linkExpireTime).
+--agent-id      — caller-declared identity for the preimage. Defaults to
+                   "unspecified-agent" if omitted (still produces a valid,
+                   recomputable action_ref — the caller is responsible for
+                   supplying a meaningful agent_id for real use).
+--timestamp     — RFC 3339 UTC, ms precision (e.g. 2026-08-20T18:00:00.000Z).
+                   Defaults to current UTC time if omitted.
+
+Prints the envelope JSON to stdout. Nothing is written to disk and nothing
+is anchored — anchoring is a separate, explicit step (see the worked
+example at giskard09/binance-onchain-pay-action-ref-anchor for how, and
+its PROVENANCE.md for what "anchored" does and does not mean).
+"""
+import argparse
+import datetime
+import hashlib
+import json
+import sys
+
+
+def jcs(obj):
+    return json.dumps(obj, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+
+
+def sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("request_json", help="pre-order request body actually sent, as a JSON string")
+    ap.add_argument("response_json", help="pre-order response actually received, as a JSON string")
+    ap.add_argument("--agent-id", default="unspecified-agent")
+    ap.add_argument("--timestamp", default=None, help="RFC 3339 UTC ms precision; defaults to now")
+    args = ap.parse_args()
+
+    try:
+        params = json.loads(args.request_json)
+    except json.JSONDecodeError as e:
+        sys.exit(f"request_json is not valid JSON: {e}")
+    try:
+        result = json.loads(args.response_json)
+    except json.JSONDecodeError as e:
+        sys.exit(f"response_json is not valid JSON: {e}")
+
+    if "externalOrderId" not in params:
+        sys.exit("request_json must include externalOrderId (per SKILL.md's pre-order table)")
+
+    timestamp = args.timestamp or datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S.") + f"{datetime.datetime.now(datetime.timezone.utc).microsecond // 1000:03d}Z"
+
+    # scope carries the network the pre-order targets, when declared —
+    # falls back to "unspecified" if the request didn't set one (network is
+    # optional in SKILL.md's pre-order table).
+    network = params.get("network", "unspecified")
+    preimage = {
+        "agent_id": args.agent_id,
+        "action_type": "binance.onchain_pay.buy.pre_order",
+        "scope": f"binance:onchain-pay:papi/v1/ramp/connect/buy/pre-order:network:{network}",
+        "timestamp": timestamp,
+    }
+    jcs_payload = jcs(preimage)
+    action_ref = sha256_hex(jcs_payload)
+
+    params_digest = sha256_hex(jcs(params))
+    result_digest = sha256_hex(jcs(result))
+
+    envelope = {
+        "packet_version": "1.0",
+        "action_ref": action_ref,
+        "hash_algo": "sha256",
+        "preimage_format": "jcs-rfc8785-v1",
+        "preimage": preimage,
+        "capability": "onchain-pay.buy.pre_order",
+        "params_digest": params_digest,
+        "result_digest": result_digest,
+        "anchor_ref_bytes32": "0x" + action_ref,
+        "generated_at_utc": timestamp,
+    }
+
+    print(json.dumps(envelope, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/binance/onchain-pay-action-ref-verify/scripts/verify_anchor.py
+++ b/skills/binance/onchain-pay-action-ref-verify/scripts/verify_anchor.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Checks whether a given action_ref has a matching Anchored(bytes32,address,
+uint256) event on AnchorRegistry, on the specified chain. Independent,
+stdlib-only — queries public RPC directly, trusts nothing passed in beyond
+the ref itself.
+
+Usage:
+    python3 verify_anchor.py <action_ref_hex> --near-block N [--chain base|arbitrum|ink] [--rpc URL]
+    python3 verify_anchor.py <action_ref_hex> --from-block A --to-block B [--chain ...]
+
+<action_ref_hex> — the action_ref to check, with or without leading 0x
+                    (64 hex chars, as printed by produce.py's envelope).
+
+Public RPC providers reject unbounded eth_getLogs (HTTP 413 / "block range
+too large") — there is no default full-chain scan. Give either
+--near-block (the block the anchor tx is claimed to be in or near; scans
++/-1000 blocks around it) or an explicit --from-block/--to-block range.
+Neither is a security requirement — the block hint only narrows the RPC
+query; the match is still verified against the actual on-chain log, not
+trusted from the hint.
+
+Exit code 0 if a matching Anchored event was found (prints tx/block/
+anchoredBy/timestamp), 1 otherwise (including "no anchor found" — the
+absence of an anchor is not an error, just a fact this script reports).
+"""
+import argparse
+import json
+import sys
+import urllib.request
+
+ANCHOR_REGISTRY = "0x49fEcA52bC634a9Ab773226D16619deC547794aa"
+# keccak256("Anchored(bytes32,address,uint256)")
+ANCHORED_TOPIC0 = "0xfe2289542f7a0110ac112c3a4d712afdcaaf2900a1326f4e6f340b563a0e8734"
+
+RPCS = {
+    "base": "https://mainnet.base.org",
+    "arbitrum": "https://arb1.arbitrum.io/rpc",
+    "ink": "https://rpc-gel.inkonchain.com",
+}
+CHAIN_IDS = {"base": 8453, "arbitrum": 42161, "ink": 57073}
+
+
+def rpc(url, method, params):
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": method, "params": params}).encode()
+    req = urllib.request.Request(
+        url, data=body,
+        headers={"Content-Type": "application/json", "User-Agent": "onchain-pay-action-ref-verify/0.1.0"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        out = json.loads(r.read())
+    if "error" in out:
+        raise RuntimeError(f"RPC {method} error: {out['error']}")
+    return out["result"]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("action_ref", help="64-hex-char action_ref, with or without 0x prefix")
+    ap.add_argument("--chain", choices=list(RPCS), default="base")
+    ap.add_argument("--rpc", default=None, help="override the default public RPC for --chain")
+    ap.add_argument("--near-block", type=int, default=None,
+                     help="block the anchor is claimed to be near; scans +/-1000 blocks")
+    ap.add_argument("--window", type=int, default=1000,
+                     help="blocks to scan on each side of --near-block (default 1000)")
+    ap.add_argument("--from-block", default=None,
+                     help="explicit start block (decimal); overrides --near-block")
+    ap.add_argument("--to-block", default=None,
+                     help="explicit end block (decimal); overrides --near-block")
+    args = ap.parse_args()
+
+    if args.from_block is not None and args.to_block is not None:
+        from_block, to_block = hex(int(args.from_block)), hex(int(args.to_block))
+    elif args.near_block is not None:
+        from_block = hex(max(0, args.near_block - args.window))
+        to_block = hex(args.near_block + args.window)
+    else:
+        sys.exit(
+            "give --near-block N (recommended) or both --from-block/--to-block — "
+            "public RPC rejects an unbounded eth_getLogs scan. See --help."
+        )
+
+    ref = args.action_ref.lower()
+    if not ref.startswith("0x"):
+        ref = "0x" + ref
+    if len(ref) != 66:
+        sys.exit(f"action_ref must be 32 bytes (64 hex chars); got {len(ref) - 2}")
+
+    url = args.rpc or RPCS[args.chain]
+
+    # Clamp to_block to the current head — a --near-block/--window (or
+    # explicit --to-block) that reaches past chain tip is a normal case
+    # (e.g. checking a recent anchor with the default window), not a user
+    # error; public RPC rejects it outright rather than clamping itself.
+    if to_block not in ("earliest", "latest", "pending"):
+        head = int(rpc(url, "eth_blockNumber", []), 16)
+        if int(to_block, 16) > head:
+            to_block = hex(head)
+
+    logs = rpc(url, "eth_getLogs", [{
+        "address": ANCHOR_REGISTRY,
+        "fromBlock": from_block,
+        "toBlock": to_block,
+        "topics": [ANCHORED_TOPIC0, ref],
+    }])
+
+    if not logs:
+        print(f"[NOT FOUND] no Anchored event for {ref} on {args.chain} "
+              f"(chainId {CHAIN_IDS[args.chain]}, registry {ANCHOR_REGISTRY})")
+        sys.exit(1)
+
+    log = logs[0]
+    ts = int(log["data"], 16)
+    anchored_by = "0x" + log["topics"][2][-40:]
+    print(f"[FOUND] Anchored event on {args.chain} (chainId {CHAIN_IDS[args.chain]})")
+    print(f"  registry         : {ANCHOR_REGISTRY}")
+    print(f"  ref              : {ref}")
+    print(f"  tx               : {log['transactionHash']}")
+    print(f"  block            : {int(log['blockNumber'], 16)}")
+    print(f"  anchoredBy       : {anchored_by}")
+    print(f"  block timestamp  : {ts}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a read-only skill that derives `action_ref` — a deterministic, content-addressed identifier (SHA-256 of RFC 8785 JCS canonicalization, per [`action-ref-v1`](https://github.com/giskard09/argentum-core/blob/master/docs/spec/action-ref.md)) — for a declared Onchain-Pay `pre-order` request/result pair, and independently verifies a claimed anchor against a permissionless `AnchorRegistry` contract on-chain.

**Why**: Binance's own Agent OS launch coverage (TechCrunch, 2026-08-20) quoted Jeff Li on the limits of visibility into agent actions: *"We really cannot see the reasoning of what the user's action is."* This skill doesn't answer *why* an action happened — that's a different problem. It answers a narrower, adjacent one: given a declared request/response pair, can any third party recompute a content-addressed identifier for it and confirm an independent, operator-external timestamp of when it was anchored on a public chain? No claim of closing the reasoning gap, no claim of Binance integration or endorsement — see the skill's "Why this exists" and "Scope and limits" sections for the exact framing.

**What's included**:
- `SKILL.md` — required frontmatter (name/description/version/author/license) per CONTRIBUTING.md.
- `scripts/produce.py` — derives `action_ref` + envelope digests from a request/response JSON you already have. No calls to Binance's API.
- `scripts/verify_anchor.py` — checks a claimed anchor against public chain RPC (Base/Arbitrum/Ink). Independent, stdlib-only.

Both commands documented in `SKILL.md` were run as-is against a real on-chain anchor before this PR (see below) — not just described.

**Worked example**: a full, independently-reproducible instance (synthetic request/response, real anchor on Base mainnet) is at [`giskard09/binance-onchain-pay-action-ref-anchor`](https://github.com/giskard09/binance-onchain-pay-action-ref-anchor) — tx [`0xe5ef165f11f01f6c3e30246319bb918be49ea7c4870cd83158b8a42e0644898a`](https://basescan.org/tx/0xe5ef165f11f01f6c3e30246319bb918be49ea7c4870cd83158b8a42e0644898a), block 50225688. Read that repo's `PROVENANCE.md` for exactly what is and isn't real about it — no live agent session or real merchant account was involved, and no adoption or endorsement by Binance is implied anywhere.

No changes to any existing skill or to Onchain-Pay's API. Happy to adjust naming/location/scope per maintainer feedback.