### PR TITLE
Add deploy-uni-hook skill

### DIFF
--- a/skills/deploy-uni-hook/README.md
+++ b/skills/deploy-uni-hook/README.md
@@ -1,0 +1,104 @@
+# deploy-uni-hook
+
+Generate, simulate, audit, and deploy a **Uniswap v4 hook** + a demo pool from a one-line
+brief - on any Uniswap v4 chain (every testnet and mainnet). Pick a pre-audited template or
+build a from-scratch freeform hook whose flags are auto-derived from its callbacks. Every
+deploy passes a static audit, a dangerous-pattern scan, a behavioral `forge` test, and a fork
+simulation **before** any broadcast. Dry-run by default; an explicit `arm:` is required to
+broadcast; mainnet sits behind a triple lock.
+
+See `SKILL.md` for the full agent instructions. This README covers install, usage, and
+dependencies.
+
+## Dependencies
+
+- **Foundry** (`forge`, `cast`, `anvil`) - installed by `scripts/setup.sh` if missing.
+- **git + curl** - used by setup to fetch Foundry and the Uniswap v4 libraries.
+
+No root access is required. Nothing else is installed globally beyond Foundry in
+`~/.foundry/bin`.
+
+## Setup (run once)
+
+```bash
+./scripts/setup.sh
+```
+
+This installs Foundry (if needed) and builds a ready-to-deploy v4 project at
+`$HOOKBUILD_DIR` (default `$HOME/hookbuild`): the v4 core/periphery libraries, all templates,
+remappings, and a pre-built `forge` project. It prints the `HOOKBUILD_DIR` to export.
+
+```bash
+export HOOKBUILD_DIR="$HOME/hookbuild"
+```
+
+## Usage
+
+The runner `hook-deploy.sh` is the only sanctioned broadcast path - it reads the deployer key
+from the environment inside the script, so the key never appears on a command line.
+
+```bash
+# list every supported Uniswap v4 chain
+./hook-deploy.sh chains
+
+# dry-run: audit + behavioral test + fork simulation, never broadcasts (default)
+./hook-deploy.sh simulate dynamic base-sepolia
+
+# broadcast to a testnet (needs HOOK_DEPLOYER_PRIVATE_KEY)
+./hook-deploy.sh broadcast dynamic base-sepolia
+```
+
+`<kind>` is `dynamic` | `noop` | `skim` (pre-audited templates) or `freeform` (an
+agent-generated hook). `<chain>` is any name in `templates/chains.tsv` (default
+`base-sepolia`).
+
+Driven by an agent, the input grammar is `[arm:][template:<name>] [chain:<name>] <brief>` -
+for example `arm: chain:base dynamic fee that rises with volatility`. See `SKILL.md`.
+
+## Environment variables
+
+| Variable | Required? | Purpose |
+|---|---|---|
+| `HOOK_DEPLOYER_PRIVATE_KEY` | broadcast only | Burner deploy key (gas float only, never LP/treasury capital). Read inside the runner; never printed. |
+| `HOOKBUILD_DIR` | recommended | Pre-built v4 project dir (default `$HOME/hookbuild`). Set from `setup.sh` output. |
+| `HOOK_MAINNET_OK` | mainnet only | Must equal `1` to allow any mainnet broadcast (third lock beyond `arm:` + explicit `chain:`). |
+| `ALCHEMY_API_KEY` | optional | Use an authenticated Alchemy RPC over the public one (a lying public RPC can fake a clean sim). |
+| `ETHERSCAN_API_KEY` | optional | Auto-verify the deployed hook source on Etherscan-family explorers (best-effort). |
+| `MAX_GAS_GWEI` | optional | Refuse to broadcast when the gas price is above this ceiling. |
+| `HOOK_MAX_FLOAT_ETH` | optional | Warn if the deployer holds more than this (default `0.25`) - a deploy key should hold gas only. |
+| `RPC_URL` | optional | Override the resolved RPC (testing / escape hatch). |
+
+## Safety
+
+- **Dry-run by default.** Broadcast only with an explicit `arm:` (agent input) or the
+  `broadcast` subcommand.
+- **Simulate before every broadcast.** A reverting simulation blocks the deploy.
+- **Mainnet triple lock.** `arm:` + explicit `chain:<mainnet>` + `HOOK_MAINNET_OK=1`, plus a
+  funding floor and an optional gas ceiling.
+- **Freeform gates.** Static audit (name/callbacks/`onlyPoolManager`/dangerous-pattern scan) +
+  a behavioral `forge test` on a fork, both before any simulation or broadcast.
+- **Gas-only exposure.** The demo pool is seeded with self-minted `MockERC20` tokens, so a
+  mainnet broadcast risks gas only - never real capital. The reusable hook contract is the
+  deliverable.
+
+## Files
+
+```
+deploy-uni-hook/
+├── SKILL.md            # agent instructions (grammar, gates, steps, degrade rules)
+├── README.md           # this file
+├── hook-deploy.sh      # key-safe deploy runner (simulate | broadcast | chains)
+├── scripts/
+│   └── setup.sh        # one-time: install Foundry + build the v4 project
+└── templates/
+    ├── DynamicFeeHook.sol   NoOpHook.sol   HookFeeHook.sol   # pre-audited templates
+    ├── Hook.sol   Hook.t.sol   hook.env.example              # freeform scaffold + test gate
+    ├── DeployHook.s.sol   MockERC20.sol   foundry.toml
+    └── chains.tsv                                            # v4 chain registry
+```
+
+## Credit
+
+Ported from the [aeon](https://github.com/aeonfun/aeon) agent framework
+(author: `aeonframework`). MIT licensed. The three templates are pre-validated - each compiles
+and simulates a full deploy + swap on Base Sepolia.

--- a/skills/deploy-uni-hook/SKILL.md
+++ b/skills/deploy-uni-hook/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: deploy-uni-hook
+description: |
+  Generate, simulate, audit, and deploy a Uniswap v4 hook + a test pool from a one-line brief,
+  on any Uniswap v4 chain (every testnet and mainnet). Use a pre-audited template
+  (dynamic-fee, no-op, or hook-fee) or build a from-scratch freeform hook whose flags are
+  auto-derived from its callbacks. Every deploy is gated: static audit + dangerous-pattern
+  scan + a behavioral forge test + a fork simulation, all BEFORE any broadcast. Dry-run by
+  default; an explicit arm: is required to broadcast; testnet is the default and mainnet sits
+  behind a triple lock. Use when the user asks to write, build, test, or deploy a Uniswap v4
+  hook, or to spin up a v4 pool with custom swap/fee/liquidity logic.
+metadata:
+  author: aeonframework
+  version: "1.0"
+license: MIT
+---
+
+# Deploy Uni Hook Skill
+
+Turn a one-line brief into a live Uniswap v4 hook. Built to be safe: it simulates every
+deploy before it broadcasts, defaults to a dry-run on a testnet, and needs an explicit
+`arm:` to move on-chain.
+
+## Input grammar
+
+The user's request is the brief. Grammar: `[arm:][template:<name>] [chain:<name>] <brief>`
+
+- `` (empty) - print this help and exit `DEPLOY_HOOK_EMPTY`.
+- `<brief>` - **dry-run**: generate, compile, mine the address, and simulate. Never broadcasts. *[default - no prefix]*
+- `arm:<brief>` - **broadcast**: run the full dry-run first, then deploy for real only if the simulation passes.
+- `template:<name>` - force a mode: `dynamic` | `noop` | `skim` (pre-audited templates) or `freeform` (build a whole hook from the prompt). Omit to auto-pick: a brief that matches a template uses it; anything else uses `freeform`.
+- `chain:<name>` - any Uniswap v4 chain in `templates/chains.tsv` (run `./hook-deploy.sh chains` to list). Default `base-sepolia`. Testnets: `base-sepolia`, `unichain-sepolia`, `arbitrum-sepolia`. Mainnets (`testnet: false`) require BOTH `arm:` and an explicit `chain:` - the skill never targets mainnet by default. `base-mainnet` is an alias for `base`.
+
+## Prerequisites
+
+This skill needs the Foundry toolchain (`forge`/`cast`/`anvil`) and a pre-built Uniswap v4
+project. Run the one-time setup, which installs Foundry (if missing) and builds the project
+at `$HOOKBUILD_DIR` (default `$HOME/hookbuild`):
+
+```bash
+./scripts/setup.sh
+```
+
+Node/Foundry are the only external dependencies. If `forge` is unavailable after setup, the
+skill degrades to `DEPLOY_HOOK_NO_TOOLCHAIN` (it emits the generated source + plan and never
+tries to install in-run).
+
+## Why this design
+
+A hook binding is immutable and a bad hook can brick a pool or trap funds, so the gates sit
+BEFORE the deploy: two of them (`dry-run` then `arm:`), a mandatory simulation, and idempotent
+state. Everything after the broadcast is just recording what already happened. The Foundry
+flow is the proven one - mine a CREATE2 salt so the address carries the right hook-flag bits,
+deploy, initialize the pool, add liquidity, run one swap.
+
+## Safety contract (do not skip)
+
+1. **Mainnet needs a triple lock.** Never target a `testnet: false` chain unless the request
+   has BOTH `arm:` AND an explicit `chain:<mainnet-name>` - AND the environment has
+   `HOOK_MAINNET_OK=1` set (a third, operator-level lock enforced inside `hook-deploy.sh`,
+   exit 7). Only run this skill where the caller is trusted - a mainnet deploy spends real
+   gas, so an untrusted request must never be able to reach a broadcast. On a mainnet chain,
+   read the deployer balance with `cast balance` and abort (`DEPLOY_HOOK_UNDERFUNDED`) if it
+   cannot cover the simulation's `Estimated amount required`; `hook-deploy.sh` independently
+   enforces a funding floor (exit 8), an optional `MAX_GAS_GWEI` gas-price ceiling (exit 9),
+   and warns if the deployer holds more than `HOOK_MAX_FLOAT_ETH` (default 0.25) - a deploy
+   key must hold gas float only, never LP or treasury capital.
+2. **Simulate before every broadcast.** If the simulation reverts, do not broadcast. Report
+   the revert and exit `DEPLOY_HOOK_SIM_FAILED`.
+3. **Dry-run is the default.** Broadcast only when the request starts with `arm:`.
+4. **Key hygiene.** The deployer key is a burner. Never print it. Never put it on a shell
+   command line - always go through `./hook-deploy.sh`, which reads it from the env inside
+   the script.
+5. **Idempotency.** Before broadcasting, read `deploys/hook-deploys.json`. If an identical
+   brief already deployed within the last hour, do not re-deploy. The deploy script is also
+   idempotent at the address level: it deploys to the *canonical* address (the first
+   flag-matching CREATE2 salt for this exact `(creationCode, flags, PoolManager)`). If that
+   address already holds code, an identical hook is already live, so the script logs
+   `ALREADY_DEPLOYED <addr>` and does nothing.
+
+## Inputs and config
+
+- **Templates:** `templates/` - `DynamicFeeHook.sol`, `NoOpHook.sol`, `HookFeeHook.sol`
+  (pre-audited), `Hook.sol` + `Hook.t.sol` + `hook.env.example` (freeform scaffold,
+  behavioral-test gate, manifest), plus `DeployHook.s.sol`, `MockERC20.sol`, `foundry.toml`,
+  `chains.tsv`.
+- **Chain config:** `templates/chains.tsv` is the single source of truth - TAB-separated
+  `name  chainId  testnet  poolManager  stateView  rpc  explorer  alchemy`, one row per
+  Uniswap v4 chain. To add a chain, append a row.
+- **Authenticated RPC:** the `rpc` column is a public endpoint. When `ALCHEMY_API_KEY` is set
+  and the row has an `alchemy` slug, `hook-deploy.sh` uses
+  `https://<slug>.g.alchemy.com/v2/$ALCHEMY_API_KEY` instead - a trusted RPC matters for the
+  mainnet sim + broadcast (a lying public RPC can fake a clean sim). Precedence: `RPC_URL`
+  (override) > Alchemy key + slug > public `rpc`. The RPC path (where the key lives) is never
+  printed - logs show host only.
+- **Deploy helper:** `hook-deploy.sh` - the only sanctioned broadcast path (hides the key).
+- **State:** `deploys/hook-deploys.json` - idempotency + the deploy ledger (local to the skill).
+
+### Template picker (when `template:` is not given)
+
+| Brief mentions | Mode |
+|---|---|
+| fee, volatility, dynamic, surge | `dynamic` |
+| skim, hook fee, take a cut, revenue | `skim` |
+| "minimal" / "starter" / "empty" | `noop` |
+| anything else (novel logic the templates don't cover) | `freeform` |
+
+## Steps
+
+1. **Parse the request.** Extract the `arm:` flag, the optional `template:`, the optional
+   `chain:`, and the free-text brief. Empty brief - exit `DEPLOY_HOOK_EMPTY` with the grammar.
+
+2. **Resolve the chain.** The chain name resolves in `templates/chains.tsv` (default
+   `base-sepolia`); `hook-deploy.sh` maps it to the official `PoolManager` + RPC, so you pass
+   the NAME, not the address. Run `./hook-deploy.sh chains` to list. If the name is unknown,
+   exit `DEPLOY_HOOK_BAD_CHAIN`. If the row's `testnet` column is `false` (mainnet), enforce
+   the double opt-in - require BOTH `arm:` and an explicit `chain:`, else exit
+   `DEPLOY_HOOK_BAD_CHAIN`.
+
+3. **Confirm the toolchain + project.** `./scripts/setup.sh` stages everything: Foundry on
+   `$PATH` and a pre-built v4 project at `$HOOKBUILD_DIR` (default `$HOME/hookbuild`) holding
+   all three templates + `MockERC20.sol` + `DeployHook.s.sol` + the v4 libraries. Check
+   `command -v forge` and that `$HOOKBUILD_DIR` exists; if either is missing, degrade to
+   `DEPLOY_HOOK_NO_TOOLCHAIN` (emit the generated source + plan).
+
+4. **Build the hook (brief-driven).**
+   - **Template mode** (`dynamic` / `noop` / `skim`): in `$HOOKBUILD_DIR/src/<Hook>.sol`, edit
+     ONLY the region between `// --- HOOK:LOGIC START ---` and `// --- HOOK:LOGIC END ---`.
+     Keep the callback signatures and flag set unchanged. If the default already fits the
+     brief, leave it.
+   - **Freeform mode** (anything else): write the whole hook into `$HOOKBUILD_DIR/src/Hook.sol`
+     - replace the `// --- HOOK:BODY ... ---` region. Rules: keep the contract name `Hook` and
+     `constructor(IPoolManager)`; implement whichever v4 callbacks the prompt needs, each with
+     the EXACT `IHooks` signature, `onlyPoolManager`, and the right selector return. Do NOT
+     hand-set flags - they are auto-derived from which callbacks you implement. If a callback
+     returns a non-zero delta, set `HOOK_RETURNS_DELTA` in `$HOOKBUILD_DIR/hook.env`; for a
+     fee-override hook set `HOOK_POOL_FEE=dynamic` there.
+     - **Also write the behavioral test.** In `$HOOKBUILD_DIR/test/Hook.t.sol`, replace the
+     `// --- HOOK:ASSERT ... ---` region with `test_*` functions that assert the hook's
+     SPECIFIC intended behavior - not just "does not revert". For every rule in the brief write
+     at least one positive and one negative case: a swap the hook must REJECT as
+     `_expectSwapRevert(zeroForOne, amount, Hook.SomeError.selector)` (this helper unwraps v4's
+     `WrappedError` - do NOT use bare `vm.expectRevert`, it won't match the wrapper); a swap it
+     must ALLOW as a plain `_swap(...)`; any getter/accounting as
+     `assertEq(hook.someGetter(...), expected)`. Do NOT edit `setUp()` or the helpers - only the
+     `HOOK:ASSERT` region.
+
+5. **Simulate + audit (always).** Pass mode, kind, and chain (chain omitted = `base-sepolia`):
+   ```bash
+   ./hook-deploy.sh simulate <kind> <chain>
+   ```
+   For `freeform` this runs, in order, three gates before any deploy:
+   1. **Static audit** - derives the flags from the callbacks; checks the contract is named
+      `Hook`, has >=1 callback, every callback carries `onlyPoolManager`, `test/Hook.t.sol` has
+      >=1 `test_` function, and scans for dangerous patterns (`selfdestruct`/`delegatecall` are
+      hard fails; `tx.origin`/raw value-call/inline `assembly` print a warning to review). A
+      failure exits `DEPLOY_HOOK_AUDIT_FAILED` (never deploy).
+   2. **Behavioral test** - `forge test --fork-url <chain> --match-contract HookBehaviorTest`
+      runs the agent-written assertions on a fork. A failing OR non-compiling test exits
+      `DEPLOY_HOOK_TEST_FAILED` (never deploy).
+   3. **Fork simulation** - `forge script` compiles, mines the salt, deploys in-memory,
+      initializes the pool, adds liquidity, and runs one swap against a fork of the target chain.
+   On a compile error, fix and retry (max 3). On a sim revert, exit `DEPLOY_HOOK_SIM_FAILED`.
+   Capture the mined hook address, the derived flags, and the `Estimated amount required`. On
+   mainnet, compare that estimate to the deployer balance (`cast balance <addr> --rpc-url
+   <rpc>`) and exit `DEPLOY_HOOK_UNDERFUNDED` if it will not cover it. For a freeform hook, also
+   **read the generated `Hook.sol` and reason about safety** before arming: does any callback
+   let a caller drain funds, brick the pool (unconditional revert), or reenter? If unsure, stop
+   at the dry-run and report the concern.
+
+6. **Dry-run stop.** If the request did NOT start with `arm:`, STOP here. Report: template,
+   mined address (with its flag bits), the pool key, and the simulation result. Exit
+   `DEPLOY_HOOK_DRY_RUN`.
+
+7. **Arm checks (only if `arm:`).**
+   - Confirm `HOOK_DEPLOYER_PRIVATE_KEY` is set. If not, degrade to the dry-run report and exit
+     `DEPLOY_HOOK_NO_KEY`.
+   - Read `deploys/hook-deploys.json`. If the same `(chain, template, brief)` deployed in the
+     last hour, exit `DEPLOY_HOOK_IDEMPOTENT` with the prior address.
+
+8. **Broadcast.**
+   ```bash
+   ./hook-deploy.sh broadcast <kind> <chain>
+   ```
+   The runner prints a **deploy receipt** (hook address, decoded flag names, explorer
+   deep-link, tx hashes) and, when `ETHERSCAN_API_KEY` is set on an Etherscan-family chain,
+   **auto-verifies** the hook source on the explorer (best-effort - a failed verify never fails
+   a completed deploy). If it printed `ALREADY_DEPLOYED`, treat the reported address as the
+   result (no new deploy). Read the hook address and tx hashes from the receipt or
+   `$HOOKBUILD_DIR/broadcast/DeployHook.s.sol/<chainId>/run-latest.json`.
+
+9. **Verify.** With `cast`, read the pool back through `StateView.getSlot0(poolId)` on the RPC.
+   Confirm the pool exists and the hook address low bits equal the template's flags. Confirm the
+   swap emitted the hook event.
+
+10. **Record the deploy.** Write the record locally (append-only history):
+    - `deploys/hook-deploys.json` - append this deploy (chain, template, brief, hook address,
+      flags, tx hashes, timestamp, poolId, poolKey).
+    - `deploys/hooks/<hook-address>.sol` - copy the deployed source from
+      `$HOOKBUILD_DIR/src/<Hook>.sol`.
+    - For freeform, also `deploys/hooks/<hook-address>.t.sol` - copy
+      `$HOOKBUILD_DIR/test/Hook.t.sol` (the behavioral test that gated the deploy).
+
+11. **Report + exit.** Summarize (template, address, explorer link, dry-run vs live). Exit
+    `DEPLOY_HOOK_OK` (or `DEPLOY_HOOK_DRY_RUN`).
+
+## Degrade rules
+
+- No key - dry-run report, `DEPLOY_HOOK_NO_KEY`. Never fail hard.
+- Foundry or the staged project missing (`command -v forge` fails or `$HOOKBUILD_DIR` absent) -
+  emit the generated source + plan, `DEPLOY_HOOK_NO_TOOLCHAIN`. Do not try to install in-run.
+- Bad/missing chain, or mainnet without the double opt-in - `DEPLOY_HOOK_BAD_CHAIN`.
+- Mainnet chain but `HOOK_MAINNET_OK=1` not set (`hook-deploy.sh` exit 7) -
+  `DEPLOY_HOOK_MAINNET_NOT_AUTHORIZED` (never broadcast).
+- Mainnet balance below the simulation estimate, or the deployer is unfunded (`hook-deploy.sh`
+  exit 8) - `DEPLOY_HOOK_UNDERFUNDED` (never broadcast).
+- Gas price above `MAX_GAS_GWEI` (`hook-deploy.sh` exit 9) - `DEPLOY_HOOK_GAS_TOO_HIGH` (never
+  broadcast; retry when fees drop).
+- Freeform static audit fails - `DEPLOY_HOOK_AUDIT_FAILED` (never deploy).
+- Freeform behavioral test fails or does not compile - `DEPLOY_HOOK_TEST_FAILED` (never deploy).
+- Simulation revert - `DEPLOY_HOOK_SIM_FAILED` (never broadcast after a failed sim).
+
+## Notes
+
+- The three templates are pre-validated: each compiles and simulates a full deploy + swap on
+  Base Sepolia (`dynamic` = 0x10C0 flags, `noop` = 0x80, `skim` = 0x44).
+- **Freeform** builds an arbitrary hook from the prompt into `src/Hook.sol` and its behavioral
+  test into `test/Hook.t.sol`. Flags are auto-derived from the callbacks (never hand-set). Three
+  gates run before any deploy: a static audit, the agent-written `forge test` behavioral
+  assertions on a fork, then the fork simulation. Prefer a matching template when one fits.
+- **Any Uniswap v4 chain works.** `chains.tsv` carries every official v4 deployment, each
+  verified to hold the PoolManager. The same flow runs on all of them - only the
+  `PoolManager`/RPC differ, resolved by name. The CREATE2 deployer (`0x4e59...4956C`) is
+  required for the mined address; if a chain lacks it the fork simulation fails closed before
+  any broadcast.
+- **Mainnet is gas-only.** The deploy mints its own `MockERC20` tokens to itself (free) and
+  seeds the demo pool with those mock tokens - a mainnet broadcast risks GAS ONLY, never real
+  capital. The deployed pool is a MockA/MockB demo; the reusable hook contract is the real
+  deliverable. The deployer key must be a funded burner holding gas float only; mainnet also
+  needs the `HOOK_MAINNET_OK=1` lock.
+- **Neutral by design.** This skill deploys infrastructure (a hook contract + a demo pool). It
+  does not recommend, rate, or promote any token or asset, and it never uses or requires a real
+  user wallet address - only a burner deploy key held in the environment.

--- a/skills/deploy-uni-hook/hook-deploy.sh
+++ b/skills/deploy-uni-hook/hook-deploy.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# hook-deploy.sh — run the Foundry deploy from the pre-staged project without
+# putting the private key on the analyzed command line. The
+# key is read INSIDE this script from $HOOK_DEPLOYER_PRIVATE_KEY, so the caller's
+# command line never contains a $SECRET token.
+#
+# Usage:
+#   ./hook-deploy.sh simulate  <dynamic|noop|skim|freeform> [chain]   # dry-run gate
+#   ./hook-deploy.sh broadcast <dynamic|noop|skim|freeform> [chain]   # armed
+#   ./hook-deploy.sh chains                                           # list chains
+#
+# chain: any name in chains.tsv (default base-sepolia). Every Uniswap v4 chain is
+#   supported (testnets + mainnets); the name resolves to its official PoolManager
+#   + RPC from chains.tsv.
+#
+# RPC: uses the public rpc from chains.tsv by default; if ALCHEMY_API_KEY is set and
+#   the row has an alchemy slug, uses the authenticated Alchemy endpoint instead.
+#   Set RPC_URL to override both (testing/escape hatch).
+#
+# Mainnet locks (all three needed to broadcast to a testnet:false chain): arm: +
+#   explicit chain: (enforced by the skill) AND HOOK_MAINNET_OK=1 (enforced here).
+#   The deployer must be funded; MAX_GAS_GWEI caps the gas price; HOOK_MAX_FLOAT_ETH
+#   warns if the deployer holds more than gas float (it must not hold LP capital).
+#
+# freeform: the agent writes $HOOKBUILD_DIR/src/Hook.sol + hook.env. This script
+# auto-derives the hook flags from which callbacks Hook.sol implements (plus any
+# HOOK_RETURNS_DELTA declared in hook.env), runs a small STATIC AUDIT, then runs
+# the same deploy. Flags are never hand-specified, so they can't drift from code.
+#
+# Env: HOOK_DEPLOYER_PRIVATE_KEY (broadcast only), HOOKBUILD_DIR, POOL_MANAGER, RPC_URL,
+#      ALCHEMY_API_KEY?, ETHERSCAN_API_KEY? (auto-verify), HOOK_MAINNET_OK?, MAX_GAS_GWEI?
+set -euo pipefail
+
+MODE="${1:?usage: hook-deploy.sh <simulate|broadcast|chains> <kind> [chain]}"
+KIND="${2:-dynamic}"
+CHAIN="${3:-base-sepolia}"
+DIR="${HOOKBUILD_DIR:-$HOME/hookbuild}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Locate the chain registry (single source of truth). Staged next to this script
+# (repo root) and inside $HOOKBUILD_DIR; also found when run from the repo.
+CHAINS="${CHAINS_FILE:-}"
+for cand in "$CHAINS" "$SCRIPT_DIR/chains.tsv" "$DIR/chains.tsv" \
+            "$SCRIPT_DIR/templates/chains.tsv"; do
+  [ -n "$cand" ] && [ -f "$cand" ] && { CHAINS="$cand"; break; }
+done
+[ -f "$CHAINS" ] || { echo "chains.tsv not found (looked near $SCRIPT_DIR and $DIR)" >&2; exit 3; }
+
+list_chains() { awk -F'\t' '!/^#/ && NF>=3 {printf "  %-18s %s\n", $1, ($3=="true"?"testnet":"mainnet")}' "$CHAINS"; }
+if [ "$MODE" = "chains" ]; then echo "known Uniswap v4 chains:"; list_chains; exit 0; fi
+
+# friendly / legacy aliases -> canonical registry names
+case "$CHAIN" in
+  base-mainnet) CHAIN=base ;;
+  eth|mainnet)  CHAIN=ethereum ;;
+  op)           CHAIN=optimism ;;
+  arb)          CHAIN=arbitrum ;;
+  avax)         CHAIN=avalanche ;;
+  bsc)          CHAIN=bnb ;;
+  matic|poly)   CHAIN=polygon ;;
+esac
+
+row="$(awk -F'\t' -v c="$CHAIN" '!/^#/ && $1==c {print; exit}' "$CHAINS")"
+if [ -z "$row" ]; then
+  { echo "unknown chain: $CHAIN. known chains:"; list_chains; } >&2
+  exit 4
+fi
+IFS=$'\t' read -r _CN CHAIN_ID TESTNET PM SV RPC EXPLORER ALCHEMY <<<"$row"
+POOL_MANAGER="${POOL_MANAGER:-$PM}"
+STATE_VIEW="${STATE_VIEW:-$SV}"
+
+# --- RPC resolution: authenticated endpoint beats the public one -----------------
+resolve_rpc() {
+  # precedence: explicit RPC_URL (testing/escape hatch) > Alchemy key+slug > public rpc
+  [ -n "${RPC_URL:-}" ] && { echo "$RPC_URL"; return; }
+  if [ -n "${ALCHEMY_API_KEY:-}" ] && [ -n "${ALCHEMY:-}" ]; then
+    echo "https://${ALCHEMY}.g.alchemy.com/v2/${ALCHEMY_API_KEY}"; return
+  fi
+  echo "$RPC"  # public fallback
+}
+RPC_URL="$(resolve_rpc)"
+# host-only label for logs — never print the path (Alchemy/Infura keys live there)
+RPC_LABEL="$(printf '%s' "$RPC_URL" | sed -E 's#(https?://[^/]+).*#\1#')"
+
+# defense-in-depth: the skill also double-gates mainnet, but make it loud here too.
+if [ "$MODE" = "broadcast" ] && [ "$TESTNET" != "true" ]; then
+  echo "!! MAINNET broadcast: chain=$CHAIN (chainId=$CHAIN_ID) — real gas. Explorer: $EXPLORER" >&2
+fi
+
+[ -d "$DIR" ] || { echo "staged project not found at $DIR — was stage-deploy-uni-hook.sh run?" >&2; exit 3; }
+cd "$DIR"
+
+# --- freeform: derive flags from the generated Hook.sol + audit ------------------
+derive_flags() {
+  local src="src/Hook.sol" f=0
+  grep -qE 'function[[:space:]]+beforeInitialize[[:space:]]*\('    "$src" && f=$((f | (1<<13)))
+  grep -qE 'function[[:space:]]+afterInitialize[[:space:]]*\('     "$src" && f=$((f | (1<<12)))
+  grep -qE 'function[[:space:]]+beforeAddLiquidity[[:space:]]*\('  "$src" && f=$((f | (1<<11)))
+  grep -qE 'function[[:space:]]+afterAddLiquidity[[:space:]]*\('   "$src" && f=$((f | (1<<10)))
+  grep -qE 'function[[:space:]]+beforeRemoveLiquidity[[:space:]]*\(' "$src" && f=$((f | (1<<9)))
+  grep -qE 'function[[:space:]]+afterRemoveLiquidity[[:space:]]*\('  "$src" && f=$((f | (1<<8)))
+  grep -qE 'function[[:space:]]+beforeSwap[[:space:]]*\('  "$src" && f=$((f | (1<<7)))
+  grep -qE 'function[[:space:]]+afterSwap[[:space:]]*\('   "$src" && f=$((f | (1<<6)))
+  grep -qE 'function[[:space:]]+beforeDonate[[:space:]]*\(' "$src" && f=$((f | (1<<5)))
+  grep -qE 'function[[:space:]]+afterDonate[[:space:]]*\('  "$src" && f=$((f | (1<<4)))
+  case ",${HOOK_RETURNS_DELTA:-}," in *,beforeSwap,*)           f=$((f | (1<<3)));; esac
+  case ",${HOOK_RETURNS_DELTA:-}," in *,afterSwap,*)            f=$((f | (1<<2)));; esac
+  case ",${HOOK_RETURNS_DELTA:-}," in *,afterAddLiquidity,*)    f=$((f | (1<<1)));; esac
+  case ",${HOOK_RETURNS_DELTA:-}," in *,afterRemoveLiquidity,*) f=$((f | (1<<0)));; esac
+  printf '0x%x' "$f"
+}
+
+# human-readable flag names from a numeric flag value (the address' low 14 bits)
+decode_flags() {
+  local v=$1 out=""
+  (( v & (1<<13) )) && out="$out beforeInitialize"
+  (( v & (1<<12) )) && out="$out afterInitialize"
+  (( v & (1<<11) )) && out="$out beforeAddLiquidity"
+  (( v & (1<<10) )) && out="$out afterAddLiquidity"
+  (( v & (1<<9)  )) && out="$out beforeRemoveLiquidity"
+  (( v & (1<<8)  )) && out="$out afterRemoveLiquidity"
+  (( v & (1<<7)  )) && out="$out beforeSwap"
+  (( v & (1<<6)  )) && out="$out afterSwap"
+  (( v & (1<<5)  )) && out="$out beforeDonate"
+  (( v & (1<<4)  )) && out="$out afterDonate"
+  (( v & (1<<3)  )) && out="$out beforeSwapReturnsDelta"
+  (( v & (1<<2)  )) && out="$out afterSwapReturnsDelta"
+  (( v & (1<<1)  )) && out="$out afterAddLiquidityReturnsDelta"
+  (( v & (1<<0)  )) && out="$out afterRemoveLiquidityReturnsDelta"
+  echo "${out# }"
+}
+
+# static scan for patterns a v4 hook almost never needs and that can steal/brick.
+# selfdestruct / delegatecall are hard fails; the rest print a warning to review.
+scan_dangerous() {
+  local src="$1" bad=0
+  grep -qE '\bselfdestruct\b'  "$src" && { echo "  FAIL: selfdestruct present (can brick the hook)"; bad=1; }
+  grep -qE '\bdelegatecall\b'  "$src" && { echo "  FAIL: delegatecall present (code-injection risk)"; bad=1; }
+  grep -qE '\btx\.origin\b'    "$src" && echo "  WARN: tx.origin used (auth smell — review)"
+  grep -qE '\.call\{[[:space:]]*value' "$src" && echo "  WARN: raw value-bearing call (review)"
+  grep -qE '\bassembly\b'      "$src" && echo "  WARN: inline assembly (review)"
+  return $bad
+}
+
+audit_freeform() {
+  local src="src/Hook.sol" fail=0
+  echo "── audit: freeform Hook.sol ──"
+  grep -qE 'contract[[:space:]]+Hook[[:space:]]' "$src" || { echo "  FAIL: contract must be named Hook"; fail=1; }
+  # count implemented callbacks
+  local cb
+  cb=$(grep -cE 'function[[:space:]]+(before|after)(Initialize|AddLiquidity|RemoveLiquidity|Swap|Donate)[[:space:]]*\(' "$src" || true)
+  echo "  callbacks implemented: $cb"
+  [ "$cb" -ge 1 ] || { echo "  FAIL: no hook callbacks found"; fail=1; }
+  # every callback must be guarded by onlyPoolManager. Count real guard sites: strip
+  # // comments (whole-line + trailing), drop the modifier DEFINITION line, then count
+  # the remaining `onlyPoolManager` tokens (one per guarded function). Robust to
+  # multi-line function signatures (external and onlyPoolManager on separate lines).
+  local guards
+  guards=$(sed -E 's://.*$::' "$src" \
+    | grep -vE 'modifier[[:space:]]+onlyPoolManager' \
+    | grep -oE '\bonlyPoolManager\b' | wc -l | tr -d ' ')
+  echo "  onlyPoolManager guards: $guards"
+  [ "$guards" -ge "$cb" ] || { echo "  FAIL: a callback is missing onlyPoolManager"; fail=1; }
+  scan_dangerous "$src" || fail=1
+  # a behavioral test must exist and actually assert something (>=1 test_ function)
+  local tests
+  tests=$(grep -cE 'function[[:space:]]+test' test/Hook.t.sol 2>/dev/null || true)
+  echo "  behavioral test_ functions: $tests"
+  [ "$tests" -ge 1 ] || { echo "  FAIL: test/Hook.t.sol has no test_ functions"; fail=1; }
+  echo "  derived flags: $(derive_flags)"
+  [ "$fail" -eq 0 ] && echo "  AUDIT PASS" || { echo "  AUDIT FAIL"; return 1; }
+}
+
+if [ "$KIND" = "freeform" ]; then
+  [ -f hook.env ] && . ./hook.env
+  audit_freeform || { echo "freeform audit failed — refusing to $MODE" >&2; exit 5; }
+  export HOOK_FLAGS="$(derive_flags)"
+  export HOOK_POOL_FEE="${HOOK_POOL_FEE:-3000}"
+  # behavioral-test gate: the agent's test/Hook.t.sol must pass on a fork of the
+  # target chain before we simulate or broadcast. Proves the hook does what the
+  # prompt asked. A failing OR non-compiling test blocks the deploy (exit 6).
+  echo "── behavioral test: forge test (fork $CHAIN) ──"
+  POOL_MANAGER="$POOL_MANAGER" HOOK_FLAGS="$HOOK_FLAGS" HOOK_POOL_FEE="$HOOK_POOL_FEE" \
+    forge test --fork-url "$RPC_URL" --match-contract HookBehaviorTest -vv \
+    || { echo "freeform behavioral test failed — refusing to $MODE" >&2; exit 6; }
+fi
+
+# a burner key is still needed for simulation (sets msg.sender); fall back to a
+# throwaway anvil key when none is set, so simulate never needs a secret.
+KEY="${HOOK_DEPLOYER_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+
+# --- broadcast preflight: mainnet lock + funding/gas guards ----------------------
+if [ "$MODE" = "broadcast" ]; then
+  : "${HOOK_DEPLOYER_PRIVATE_KEY:?set HOOK_DEPLOYER_PRIVATE_KEY to broadcast}"
+
+  # third mainnet lock (beyond the skill's arm: + explicit chain:). An instance
+  # must opt into mainnet by setting HOOK_MAINNET_OK=1 — a stray armed message
+  # can't reach mainnet on an instance that never authorized it.
+  if [ "$TESTNET" != "true" ] && [ "${HOOK_MAINNET_OK:-}" != "1" ]; then
+    echo "mainnet broadcast blocked: set HOOK_MAINNET_OK=1 to authorize mainnet on this instance" >&2
+    exit 7
+  fi
+
+  if command -v cast >/dev/null 2>&1; then
+    DEPLOYER="$(cast wallet address --private-key "$KEY" 2>/dev/null || true)"
+    BAL="$(cast balance "${DEPLOYER:-0x0000000000000000000000000000000000000000}" --rpc-url "$RPC_URL" --ether 2>/dev/null || echo 0)"
+    echo "deployer $DEPLOYER  balance ${BAL} (native, $CHAIN)"
+    # funding floor — never broadcast from an empty deployer
+    awk -v b="$BAL" 'BEGIN{exit !(b+0>0)}' || {
+      echo "deployer unfunded on $CHAIN — fund $DEPLOYER before arming" >&2; exit 8; }
+    # optional gas-price ceiling — refuse to deploy into a fee spike
+    if [ -n "${MAX_GAS_GWEI:-}" ]; then
+      GP="$(cast gas-price --rpc-url "$RPC_URL" 2>/dev/null || echo 0)"
+      if awk -v g="$GP" -v c="$MAX_GAS_GWEI" 'BEGIN{exit !(g/1e9 > c+0)}'; then
+        echo "gas price $(awk -v g="$GP" 'BEGIN{printf "%.2f", g/1e9}') gwei > cap ${MAX_GAS_GWEI} gwei — refusing to broadcast" >&2
+        exit 9
+      fi
+    fi
+    # float ceiling — the deployer must hold GAS ONLY, never LP/treasury capital
+    if [ "$TESTNET" != "true" ]; then
+      CEIL="${HOOK_MAX_FLOAT_ETH:-0.25}"
+      awk -v b="$BAL" -v c="$CEIL" 'BEGIN{exit !(b+0>c+0)}' \
+        && echo "!! WARN deployer holds ${BAL} > float ceiling ${CEIL} — a deploy key must hold gas only, not capital" >&2
+    fi
+  fi
+fi
+
+ARGS=(script script/DeployHook.s.sol:DeployHook --rpc-url "$RPC_URL" --private-key "$KEY")
+[ "$MODE" = "broadcast" ] && ARGS+=(--broadcast --slow)
+
+echo "hook-deploy: $MODE kind=$KIND chain=$CHAIN chainId=$CHAIN_ID rpc=$RPC_LABEL poolManager=$POOL_MANAGER stateView=$STATE_VIEW${HOOK_FLAGS:+ flags=$HOOK_FLAGS}"
+
+# run forge, capturing output so we can print a receipt + auto-verify afterwards
+LOG="$(mktemp)"
+set +e
+POOL_MANAGER="$POOL_MANAGER" HOOK_KIND="$KIND" forge "${ARGS[@]}" 2>&1 | tee "$LOG"
+rc=${PIPESTATUS[0]}
+set -e
+[ "$rc" -ne 0 ] && { rm -f "$LOG"; exit "$rc"; }
+
+# idempotency: the deploy script logs ALREADY_DEPLOYED <addr> and does nothing when
+# the mined hook address already holds code. Surface it cleanly (not an error).
+if grep -q "ALREADY_DEPLOYED" "$LOG"; then
+  ADDR="$(grep -oE '0x[a-fA-F0-9]{40}' <(grep ALREADY_DEPLOYED "$LOG") | head -1)"
+  echo "── already deployed ──"
+  echo "  this exact hook (same code+flags+PoolManager) is already live at $ADDR"
+  echo "  explorer  $EXPLORER/address/$ADDR"
+  rm -f "$LOG"; exit 0
+fi
+
+# --- receipt (both modes): mined hook address + decoded flags + explorer link -----
+HOOK_ADDR="$(grep -oE '0x[a-fA-F0-9]{40}' <(grep -E '^[[:space:]]*hook[[:space:]]' "$LOG") | head -1)"
+if [ -n "$HOOK_ADDR" ]; then
+  FLAGBITS=$(( 0x${HOOK_ADDR: -4} & 0x3fff ))
+  echo "──────── deploy receipt ($MODE) ────────"
+  echo "  chain     $CHAIN ($CHAIN_ID)"
+  echo "  hook      $HOOK_ADDR"
+  printf '  flags     0x%x  %s\n' "$FLAGBITS" "$(decode_flags "$FLAGBITS")"
+  echo "  explorer  $EXPLORER/address/$HOOK_ADDR"
+  if [ "$MODE" = "broadcast" ]; then
+    RUNJSON="broadcast/DeployHook.s.sol/$CHAIN_ID/run-latest.json"
+    if command -v jq >/dev/null 2>&1 && [ -f "$RUNJSON" ]; then
+      echo "  txs:"
+      jq -r '.transactions[]? | "    " + (.hash // .transactionHash // "?") + "  " + (.contractName // .transactionType // "")' "$RUNJSON" 2>/dev/null | head -12 || true
+    fi
+  fi
+fi
+
+# --- auto-verify on the block explorer (best-effort; never fails a done deploy) ---
+# The hook is deployed through the CREATE2 factory (0x4e59…), so IMMEDIATELY after a
+# broadcast Etherscan hasn't indexed the factory's internal creation tx yet and the
+# first submit fails with "Compiled contract deployment bytecode does NOT match the
+# transaction deployment bytecode". This is a TIMING issue, not a real mismatch:
+# once indexing catches up (usually a minute or two) the same submit passes. So we
+# RE-SUBMIT with backoff (proven live on 0xAF6f… base mainnet) — `--watch` alone only
+# polls the queue for a submission that already failed, it never re-submits.
+if [ "$MODE" = "broadcast" ] && [ -n "$HOOK_ADDR" ] && [ -n "${ETHERSCAN_API_KEY:-}" ]; then
+  case "$KIND" in
+    dynamic) CNAME="src/DynamicFeeHook.sol:DynamicFeeHook" ;;
+    noop)    CNAME="src/NoOpHook.sol:NoOpHook" ;;
+    skim)    CNAME="src/HookFeeHook.sol:HookFeeHook" ;;
+    *)       CNAME="src/Hook.sol:Hook" ;;
+  esac
+  echo "── verify: $CNAME on chain $CHAIN_ID (best-effort, retries for CREATE2 indexing) ──"
+  CARGS="$(cast abi-encode 'constructor(address)' "$POOL_MANAGER" 2>/dev/null || true)"
+  VTRIES="${HOOK_VERIFY_RETRIES:-6}"; VBACKOFF="${HOOK_VERIFY_BACKOFF:-30}"; vok=0
+  for ((vi=1; vi<=VTRIES; vi++)); do
+    vout="$(forge verify-contract "$HOOK_ADDR" "$CNAME" \
+              --chain-id "$CHAIN_ID" --etherscan-api-key "$ETHERSCAN_API_KEY" \
+              --constructor-args "$CARGS" --watch 2>&1)"
+    if printf '%s' "$vout" | grep -qiE 'Pass - Verified|successfully verified|already verified'; then
+      echo "  verify: OK on attempt $vi ($EXPLORER/address/$HOOK_ADDR#code)"; vok=1; break
+    fi
+    echo "  verify: attempt $vi/$VTRIES not confirmed (explorer still indexing the CREATE2 tx)"
+    [ "$vi" -lt "$VTRIES" ] && sleep "$VBACKOFF"
+  done
+  [ "$vok" -eq 1 ] || echo "  WARN verify not confirmed after $VTRIES attempts — deploy is unaffected; source in output/hooks/, re-run 'forge verify-contract' later (or explorer is non-Etherscan)" >&2
+fi
+
+rm -f "$LOG"
+exit 0

--- a/skills/deploy-uni-hook/scripts/setup.sh
+++ b/skills/deploy-uni-hook/scripts/setup.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# setup.sh - one-time setup for the deploy-uni-hook skill.
+#
+# Installs the Foundry toolchain (forge/cast/anvil) if it is missing, then builds a
+# ready-to-deploy Uniswap v4 project at $HOOKBUILD_DIR (default $HOME/hookbuild):
+# the v4 libraries + all skill templates + remappings, pre-built with `forge build`.
+# After this runs, the skill only edits a template's logic region and calls
+# `./hook-deploy.sh simulate|broadcast <kind>` - no install, no v4 clone at run time.
+#
+# Idempotent-ish: it rebuilds $HOOKBUILD_DIR from scratch each run. Best-effort:
+# never hard-fails (exit 0), so the skill can degrade to DEPLOY_HOOK_NO_TOOLCHAIN.
+#
+# Requirements: git, curl, and Node.js are NOT required; Foundry pulls its own libs.
+set -uo pipefail
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TPL="$SKILL_DIR/templates"
+DIR="${HOOKBUILD_DIR:-$HOME/hookbuild}"
+
+log() { echo "setup: $*"; }
+
+# 1) Foundry -> ~/.foundry/bin, made resolvable for this shell (and later CI steps).
+if ! command -v forge >/dev/null 2>&1; then
+  log "installing Foundry..."
+  curl -L https://foundry.paradigm.xyz | bash >/dev/null 2>&1 || true
+  "$HOME/.foundry/bin/foundryup" >/dev/null 2>&1 || true
+fi
+if [ -x "$HOME/.foundry/bin/forge" ]; then
+  export PATH="$HOME/.foundry/bin:$PATH"
+  # persist to PATH in CI (GitHub Actions) if present; a no-op locally.
+  [ -n "${GITHUB_PATH:-}" ] && echo "$HOME/.foundry/bin" >> "$GITHUB_PATH"
+fi
+if ! command -v forge >/dev/null 2>&1; then
+  log "WARN forge unavailable after install - add ~/.foundry/bin to PATH or install Foundry manually (https://getfoundry.sh). The skill will degrade to NO_TOOLCHAIN."
+  exit 0
+fi
+log "$(forge --version 2>/dev/null | head -1)"
+
+# 2) Scratch project: v4 libs + templates + remappings, pre-built.
+log "building v4 project at $DIR ..."
+rm -rf "$DIR"; mkdir -p "$DIR"; cd "$DIR" || { log "WARN cannot enter $DIR"; exit 0; }
+forge init --force . >/dev/null 2>&1 || true
+rm -f src/Counter.sol script/Counter.s.sol test/Counter.t.sol
+forge install uniswap/v4-core >/dev/null 2>&1 || log "WARN v4-core install failed"
+forge install uniswap/v4-periphery >/dev/null 2>&1 || log "WARN v4-periphery install failed"
+
+cat > remappings.txt <<'EOF'
+@uniswap/v4-core/=lib/v4-core/
+@uniswap/v4-periphery/=lib/v4-periphery/
+v4-core/=lib/v4-core/
+v4-periphery/=lib/v4-periphery/
+forge-std/=lib/forge-std/src/
+solmate/=lib/v4-core/lib/solmate/
+openzeppelin-contracts/=lib/v4-core/lib/openzeppelin-contracts/
+EOF
+cp "$TPL/foundry.toml" foundry.toml
+cp "$TPL/DynamicFeeHook.sol" "$TPL/NoOpHook.sol" "$TPL/HookFeeHook.sol" "$TPL/MockERC20.sol" src/
+cp "$TPL/Hook.sol" src/                 # freeform scaffold (agent rewrites its body)
+cp "$TPL/DeployHook.s.sol" script/
+cp "$TPL/Hook.t.sol" test/              # freeform behavioral-test gate (agent writes HOOK:ASSERT)
+cp "$TPL/hook.env.example" hook.env     # freeform manifest defaults (agent overwrites)
+cp "$TPL/chains.tsv" chains.tsv         # v4 chain registry (name -> PoolManager + RPC)
+
+if forge build >/dev/null 2>&1; then
+  log "project built at $DIR"
+else
+  log "WARN initial forge build failed (the agent can retry after editing logic)"
+fi
+
+# 3) Make the key-safe runner executable; export the build dir for the current shell.
+chmod +x "$SKILL_DIR/hook-deploy.sh" 2>/dev/null || true
+[ -n "${GITHUB_ENV:-}" ] && echo "HOOKBUILD_DIR=$DIR" >> "$GITHUB_ENV"
+log "done. export HOOKBUILD_DIR=$DIR   (then run ./hook-deploy.sh simulate <kind> <chain>)"
+exit 0

--- a/skills/deploy-uni-hook/templates/DeployHook.s.sol
+++ b/skills/deploy-uni-hook/templates/DeployHook.s.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// TEMPLATE: deploy one hook + a fresh test pool, then run one swap.
+// Env:
+//   POOL_MANAGER  (required) - the v4 PoolManager for the target chain
+//   HOOK_KIND     (optional) - "dynamic" | "noop" | "skim"  (default "dynamic")
+//
+// Run WITHOUT --broadcast to simulate (the dry-run gate).
+// Run WITH --broadcast to deploy for real (armed).
+//
+// NOTE (funds): the pool is seeded with MockERC20 tokens this script mints to
+// itself (free) — a mainnet broadcast risks GAS ONLY, never real capital. The
+// deployed pool is a MockA/MockB demo; the hook contract is the real deliverable.
+
+import {Script, console2} from "forge-std/Script.sol";
+
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {LPFeeLibrary} from "@uniswap/v4-core/src/libraries/LPFeeLibrary.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {PoolModifyLiquidityTest} from "@uniswap/v4-core/src/test/PoolModifyLiquidityTest.sol";
+import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
+
+import {HookMiner} from "v4-periphery/test/shared/HookMiner.sol";
+
+import {MockERC20} from "../src/MockERC20.sol";
+import {DynamicFeeHook} from "../src/DynamicFeeHook.sol";
+import {NoOpHook} from "../src/NoOpHook.sol";
+import {HookFeeHook} from "../src/HookFeeHook.sol";
+import {Hook} from "../src/Hook.sol"; // freeform (agent-generated)
+
+contract DeployHook is Script {
+    address constant CREATE2_DEPLOYER = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+
+    PoolKey key;
+    PoolSwapTest swapRouter;
+
+    // First CREATE2 address whose low 14 bits match `flags`, IGNORING existing code
+    // (HookMiner.find additionally requires empty code, so it skips this once occupied).
+    // Mirrors HookMiner constants: deployer 0x4e59…, mask Hooks.ALL_HOOK_MASK, 160_444 loop.
+    function _canonicalAddr(uint160 flags, bytes memory initCode, bytes memory ctorArgs)
+        internal
+        pure
+        returns (address)
+    {
+        uint160 mask = Hooks.ALL_HOOK_MASK;
+        bytes32 ich = keccak256(abi.encodePacked(initCode, ctorArgs));
+        flags = flags & mask;
+        for (uint256 salt; salt < 160_444; salt++) {
+            address a = address(
+                uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), CREATE2_DEPLOYER, salt, ich))))
+            );
+            if (uint160(a) & mask == flags) return a;
+        }
+        revert("no canonical salt");
+    }
+
+    function run() external {
+        IPoolManager pm = IPoolManager(vm.envAddress("POOL_MANAGER"));
+        string memory kind = vm.envOr("HOOK_KIND", string("dynamic"));
+        bytes32 k = keccak256(bytes(kind));
+
+        // choose flags + init code + fee by kind (pure selection — no broadcast yet)
+        uint160 flags;
+        bytes memory initCode;
+        uint24 poolFee;
+        if (k == keccak256("dynamic")) {
+            flags = uint160(Hooks.AFTER_INITIALIZE_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG);
+            initCode = type(DynamicFeeHook).creationCode;
+            poolFee = LPFeeLibrary.DYNAMIC_FEE_FLAG;
+        } else if (k == keccak256("noop")) {
+            flags = uint160(Hooks.BEFORE_SWAP_FLAG);
+            initCode = type(NoOpHook).creationCode;
+            poolFee = 3000;
+        } else if (k == keccak256("skim")) {
+            flags = uint160(Hooks.AFTER_SWAP_FLAG | Hooks.AFTER_SWAP_RETURNS_DELTA_FLAG);
+            initCode = type(HookFeeHook).creationCode;
+            poolFee = 3000;
+        } else if (k == keccak256("freeform")) {
+            // flags auto-derived by hook-deploy.sh and passed in; fee from the manifest
+            flags = uint160(vm.envUint("HOOK_FLAGS"));
+            initCode = type(Hook).creationCode;
+            string memory pf = vm.envOr("HOOK_POOL_FEE", string("3000"));
+            poolFee = keccak256(bytes(pf)) == keccak256("dynamic")
+                ? LPFeeLibrary.DYNAMIC_FEE_FLAG
+                : uint24(vm.parseUint(pf));
+        } else {
+            revert("unknown HOOK_KIND");
+        }
+
+        // idempotency: the CANONICAL address is the first flag-matching CREATE2 salt
+        // IGNORING code. The first deploy of this exact (creationCode, flags, pm) lands
+        // there; HookMiner skips occupied addresses, so a later identical deploy would
+        // land elsewhere. Thus if the canonical address already holds code, an identical
+        // hook is already live — report it and stop (never a silent duplicate instance).
+        address canonical = _canonicalAddr(flags, initCode, abi.encode(pm));
+        if (canonical.code.length > 0) {
+            console2.log("ALREADY_DEPLOYED", canonical);
+            return;
+        }
+
+        // mine the CREATE2 salt so the hook address carries the right flag bits. The
+        // canonical address is empty here, so HookMiner returns exactly it (stable).
+        (address expected, bytes32 salt) = HookMiner.find(CREATE2_DEPLOYER, flags, initCode, abi.encode(pm));
+
+        address me = msg.sender;
+        vm.startBroadcast();
+
+        // tokens (minted to self — no real value; the pool is a demo)
+        MockERC20 tA = new MockERC20("Hook Test A", "HTA");
+        MockERC20 tB = new MockERC20("Hook Test B", "HTB");
+        tA.mint(me, 1e27);
+        tB.mint(me, 1e27);
+        (Currency c0, Currency c1) = address(tA) < address(tB)
+            ? (Currency.wrap(address(tA)), Currency.wrap(address(tB)))
+            : (Currency.wrap(address(tB)), Currency.wrap(address(tA)));
+
+        // deploy the hook at the mined address
+        address hookAddr;
+        if (k == keccak256("dynamic")) {
+            hookAddr = address(new DynamicFeeHook{salt: salt}(pm));
+        } else if (k == keccak256("noop")) {
+            hookAddr = address(new NoOpHook{salt: salt}(pm));
+        } else if (k == keccak256("skim")) {
+            hookAddr = address(new HookFeeHook{salt: salt}(pm));
+        } else {
+            hookAddr = address(new Hook{salt: salt}(pm));
+        }
+        require(hookAddr == expected, "hook addr mismatch");
+        require(uint160(hookAddr) & Hooks.ALL_HOOK_MASK == flags, "flag bits wrong");
+
+        // pool + init at 1:1
+        key = PoolKey({currency0: c0, currency1: c1, fee: poolFee, tickSpacing: 60, hooks: IHooks(hookAddr)});
+        pm.initialize(key, 79228162514264337593543950336);
+
+        // routers + liquidity
+        PoolModifyLiquidityTest lpRouter = new PoolModifyLiquidityTest(pm);
+        swapRouter = new PoolSwapTest(pm);
+        tA.approve(address(lpRouter), type(uint256).max);
+        tB.approve(address(lpRouter), type(uint256).max);
+        tA.approve(address(swapRouter), type(uint256).max);
+        tB.approve(address(swapRouter), type(uint256).max);
+        lpRouter.modifyLiquidity(
+            key,
+            IPoolManager.ModifyLiquidityParams({
+                tickLower: TickMath.minUsableTick(60),
+                tickUpper: TickMath.maxUsableTick(60),
+                liquidityDelta: 1e21,
+                salt: bytes32(0)
+            }),
+            ""
+        );
+
+        // one test swap - proves the hook callback path does not revert
+        swapRouter.swap(
+            key,
+            IPoolManager.SwapParams({
+                zeroForOne: true,
+                amountSpecified: -1e15,
+                sqrtPriceLimitX96: TickMath.MIN_SQRT_PRICE + 1
+            }),
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}),
+            ""
+        );
+
+        vm.stopBroadcast();
+
+        console2.log("kind        ", kind);
+        console2.log("hook        ", hookAddr);
+        console2.log("token0      ", Currency.unwrap(c0));
+        console2.log("token1      ", Currency.unwrap(c1));
+        console2.log("swapRouter  ", address(swapRouter));
+        console2.log("poolManager ", address(pm));
+    }
+}

--- a/skills/deploy-uni-hook/templates/DynamicFeeHook.sol
+++ b/skills/deploy-uni-hook/templates/DynamicFeeHook.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// TEMPLATE: dynamic-fee hook.
+// Flags required in the address: AFTER_INITIALIZE, BEFORE_SWAP, AFTER_SWAP (0x10C0).
+// The pool MUST be initialized with fee = LPFeeLibrary.DYNAMIC_FEE_FLAG.
+//
+// Default logic = volatility fee: the fee for a swap grows with the price move
+// of the previous swap. Edit `_computeFee` to change the policy (time decay,
+// directional fee, volume tiers, etc.). Keep the HOOK:LOGIC markers so the
+// deploy-uni-hook skill can find the region it may rewrite.
+
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
+import {LPFeeLibrary} from "@uniswap/v4-core/src/libraries/LPFeeLibrary.sol";
+import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+
+contract DynamicFeeHook {
+    using PoolIdLibrary for PoolKey;
+    using StateLibrary for IPoolManager;
+
+    IPoolManager public immutable poolManager;
+
+    // fee parameters (hundredths of a bip; 3000 = 0.30%)
+    uint24 public constant BASE_FEE = 3000;
+    uint24 public constant MIN_FEE = 500;
+    uint24 public constant MAX_FEE = 50000;
+    uint24 public constant FEE_PER_TICK = 100;
+
+    mapping(PoolId => int24) public tickAtSwapStart;
+    mapping(PoolId => uint256) public lastMove;
+
+    event DynamicFee(PoolId indexed id, uint256 lastMove, uint24 feeApplied);
+
+    error NotPoolManager();
+
+    constructor(IPoolManager _pm) {
+        poolManager = _pm;
+    }
+
+    modifier onlyPoolManager() {
+        if (msg.sender != address(poolManager)) revert NotPoolManager();
+        _;
+    }
+
+    function afterInitialize(address, PoolKey calldata key, uint160, int24 tick)
+        external
+        onlyPoolManager
+        returns (bytes4)
+    {
+        tickAtSwapStart[key.toId()] = tick;
+        return IHooks.afterInitialize.selector;
+    }
+
+    function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, bytes calldata)
+        external
+        onlyPoolManager
+        returns (bytes4, BeforeSwapDelta, uint24)
+    {
+        PoolId id = key.toId();
+        (, int24 curTick,,) = poolManager.getSlot0(id);
+        tickAtSwapStart[id] = curTick;
+
+        uint24 fee = _computeFee(id);
+        emit DynamicFee(id, lastMove[id], fee);
+        return (IHooks.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, fee | LPFeeLibrary.OVERRIDE_FEE_FLAG);
+    }
+
+    function afterSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, BalanceDelta, bytes calldata)
+        external
+        onlyPoolManager
+        returns (bytes4, int128)
+    {
+        PoolId id = key.toId();
+        (, int24 newTick,,) = poolManager.getSlot0(id);
+        int256 diff = int256(newTick) - int256(tickAtSwapStart[id]);
+        lastMove[id] = diff >= 0 ? uint256(diff) : uint256(-diff);
+        return (IHooks.afterSwap.selector, int128(0));
+    }
+
+    // --- HOOK:LOGIC START (the deploy-uni-hook skill may rewrite this body) ---
+    function _computeFee(PoolId id) internal view returns (uint24) {
+        uint256 fee = uint256(BASE_FEE) + lastMove[id] * uint256(FEE_PER_TICK);
+        if (fee < MIN_FEE) return MIN_FEE;
+        if (fee > MAX_FEE) return MAX_FEE;
+        return uint24(fee);
+    }
+    // --- HOOK:LOGIC END ---
+}

--- a/skills/deploy-uni-hook/templates/Hook.sol
+++ b/skills/deploy-uni-hook/templates/Hook.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// FREEFORM hook scaffold. In freeform mode the deploy-uni-hook skill rewrites the
+// HOOK:BODY region with callbacks generated from the user's prompt.
+//
+// Rules the generator MUST keep:
+//   - Contract name stays `Hook` and constructor stays `constructor(IPoolManager)`
+//     (the deploy script imports `Hook` by name).
+//   - Every callback uses the EXACT IHooks signature, carries `onlyPoolManager`,
+//     and returns the right selector (e.g. `IHooks.beforeSwap.selector`).
+//   - Flags are AUTO-DERIVED from which callbacks exist (see hook-deploy.sh).
+//     For a return-delta callback, also list it in hook.env HOOK_RETURNS_DELTA.
+//   - A dynamic-fee hook sets HOOK_POOL_FEE=dynamic in hook.env and returns
+//     `fee | LPFeeLibrary.OVERRIDE_FEE_FLAG` from beforeSwap.
+//
+// All commonly-needed imports/usings are here so generated bodies compile as-is.
+
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
+import {BalanceDelta, BalanceDeltaLibrary} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
+import {LPFeeLibrary} from "@uniswap/v4-core/src/libraries/LPFeeLibrary.sol";
+import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+
+contract Hook {
+    using PoolIdLibrary for PoolKey;
+    using StateLibrary for IPoolManager;
+    using BalanceDeltaLibrary for BalanceDelta;
+    using CurrencyLibrary for Currency;
+
+    IPoolManager public immutable poolManager;
+
+    error NotPoolManager();
+
+    constructor(IPoolManager _pm) {
+        poolManager = _pm;
+    }
+
+    modifier onlyPoolManager() {
+        if (msg.sender != address(poolManager)) revert NotPoolManager();
+        _;
+    }
+
+    // --- HOOK:BODY START (freeform: replace with callbacks from the prompt) ---
+    // Default scaffold = a no-op afterSwap counter, so the file compiles and is a
+    // working example. Auto-derived flags for this default: AFTER_SWAP (0x40).
+    mapping(PoolId => uint256) public swapCount;
+
+    event SwapCounted(PoolId indexed id, uint256 count);
+
+    function afterSwap(
+        address,
+        PoolKey calldata key,
+        IPoolManager.SwapParams calldata,
+        BalanceDelta,
+        bytes calldata
+    ) external onlyPoolManager returns (bytes4, int128) {
+        PoolId id = key.toId();
+        swapCount[id] += 1;
+        emit SwapCounted(id, swapCount[id]);
+        return (IHooks.afterSwap.selector, int128(0));
+    }
+    // --- HOOK:BODY END ---
+}

--- a/skills/deploy-uni-hook/templates/Hook.t.sol
+++ b/skills/deploy-uni-hook/templates/Hook.t.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// FREEFORM behavioral test. In freeform mode the deploy-uni-hook skill rewrites the
+// HOOK:ASSERT region with `test_*` functions that assert the hook's SPECIFIC
+// intended behavior (a swap that should revert reverts; a state getter returns the
+// right value; a fee is skimmed; etc.). hook-deploy.sh runs
+//   forge test --fork-url <chain> --match-contract HookBehaviorTest
+// as a GATE before it will simulate or broadcast. A failing (or non-compiling) test
+// blocks the deploy (DEPLOY_HOOK_TEST_FAILED). This proves the hook does what the
+// prompt asked, not just that it does not revert.
+//
+// setUp() below is fixed scaffolding: it forks the target chain, mines + deploys the
+// generated Hook with its auto-derived flags, opens a fresh pool, and adds deep
+// liquidity. The generator MUST NOT edit setUp() or the helpers — only HOOK:ASSERT.
+
+import {Test} from "forge-std/Test.sol";
+
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {LPFeeLibrary} from "@uniswap/v4-core/src/libraries/LPFeeLibrary.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {PoolModifyLiquidityTest} from "@uniswap/v4-core/src/test/PoolModifyLiquidityTest.sol";
+import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
+
+import {HookMiner} from "v4-periphery/test/shared/HookMiner.sol";
+
+import {MockERC20} from "../src/MockERC20.sol";
+import {Hook} from "../src/Hook.sol";
+
+contract HookBehaviorTest is Test {
+    using PoolIdLibrary for PoolKey;
+
+    IPoolManager internal pm;
+    Hook internal hook;
+    PoolKey internal key;
+    PoolModifyLiquidityTest internal lpRouter;
+    PoolSwapTest internal swapRouter;
+    MockERC20 internal tA;
+    MockERC20 internal tB;
+
+    function setUp() public {
+        pm = IPoolManager(vm.envAddress("POOL_MANAGER"));
+        uint160 flags = uint160(vm.envUint("HOOK_FLAGS"));
+        string memory pf = vm.envOr("HOOK_POOL_FEE", string("3000"));
+        uint24 poolFee =
+            keccak256(bytes(pf)) == keccak256("dynamic") ? LPFeeLibrary.DYNAMIC_FEE_FLAG : uint24(vm.parseUint(pf));
+
+        // tokens
+        tA = new MockERC20("Hook Test A", "HTA");
+        tB = new MockERC20("Hook Test B", "HTB");
+        tA.mint(address(this), 1e30);
+        tB.mint(address(this), 1e30);
+        (Currency c0, Currency c1) = address(tA) < address(tB)
+            ? (Currency.wrap(address(tA)), Currency.wrap(address(tB)))
+            : (Currency.wrap(address(tB)), Currency.wrap(address(tA)));
+
+        // mine + deploy the generated hook at an address carrying its flag bits.
+        // Mine with THIS contract as the CREATE2 deployer so `new Hook{salt}` matches.
+        (address expected, bytes32 salt) = HookMiner.find(address(this), flags, type(Hook).creationCode, abi.encode(pm));
+        hook = new Hook{salt: salt}(pm);
+        require(address(hook) == expected, "hook addr mismatch");
+        require(uint160(address(hook)) & Hooks.ALL_HOOK_MASK == flags, "flag bits wrong");
+
+        // pool at 1:1 + deep full-range liquidity so multi-1e18 swaps do not run dry
+        key = PoolKey({currency0: c0, currency1: c1, fee: poolFee, tickSpacing: 60, hooks: IHooks(address(hook))});
+        pm.initialize(key, 79228162514264337593543950336);
+
+        lpRouter = new PoolModifyLiquidityTest(pm);
+        swapRouter = new PoolSwapTest(pm);
+        tA.approve(address(lpRouter), type(uint256).max);
+        tB.approve(address(lpRouter), type(uint256).max);
+        tA.approve(address(swapRouter), type(uint256).max);
+        tB.approve(address(swapRouter), type(uint256).max);
+        lpRouter.modifyLiquidity(
+            key,
+            IPoolManager.ModifyLiquidityParams({
+                tickLower: TickMath.minUsableTick(60),
+                tickUpper: TickMath.maxUsableTick(60),
+                liquidityDelta: 1e23,
+                salt: bytes32(0)
+            }),
+            ""
+        );
+    }
+
+    /// @dev Run one swap. amountSpecified < 0 = exact-input of that size.
+    function _swap(bool zeroForOne, int256 amountSpecified) internal returns (BalanceDelta) {
+        return swapRouter.swap(
+            key,
+            IPoolManager.SwapParams({
+                zeroForOne: zeroForOne,
+                amountSpecified: amountSpecified,
+                sqrtPriceLimitX96: zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1
+            }),
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}),
+            ""
+        );
+    }
+
+    /// @dev Assert a swap reverts AND the hook's own error is the cause. v4 wraps a
+    /// hook revert in CustomRevert.WrappedError, so we scan the revert bytes for the
+    /// hook error's 4-byte selector rather than matching the outer wrapper.
+    /// Use for negative cases: _expectSwapRevert(true, -6e18, Hook.SomeError.selector).
+    function _expectSwapRevert(bool zeroForOne, int256 amountSpecified, bytes4 hookErrorSelector) internal {
+        try swapRouter.swap(
+            key,
+            IPoolManager.SwapParams({
+                zeroForOne: zeroForOne,
+                amountSpecified: amountSpecified,
+                sqrtPriceLimitX96: zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1
+            }),
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}),
+            ""
+        ) {
+            revert("expected swap to revert but it succeeded");
+        } catch (bytes memory err) {
+            assertTrue(_containsSelector(err, hookErrorSelector), "reverted with the wrong error");
+        }
+    }
+
+    function _containsSelector(bytes memory data, bytes4 sel) internal pure returns (bool) {
+        if (data.length < 4) return false;
+        for (uint256 i = 0; i + 4 <= data.length; i++) {
+            if (data[i] == sel[0] && data[i + 1] == sel[1] && data[i + 2] == sel[2] && data[i + 3] == sel[3]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // --- HOOK:ASSERT START (freeform: replace with behavioral tests for the prompt) ---
+    // Default scaffold matches the default Hook body (an afterSwap swap counter).
+    // The generator MUST replace this with assertions specific to the generated hook:
+    //   - a swap the hook is meant to REJECT -> vm.expectRevert(...) then _swap(...)
+    //   - a swap the hook is meant to ALLOW  -> _swap(...) with no revert
+    //   - any getter / accounting -> assertEq(hook.someGetter(...), expected)
+    function test_defaultCounterIncrements() public {
+        _swap(true, -1e15);
+        assertEq(hook.swapCount(key.toId()), 1, "counter did not increment");
+        _swap(true, -1e15);
+        assertEq(hook.swapCount(key.toId()), 2, "counter did not increment twice");
+    }
+    // --- HOOK:ASSERT END ---
+}

--- a/skills/deploy-uni-hook/templates/HookFeeHook.sol
+++ b/skills/deploy-uni-hook/templates/HookFeeHook.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// TEMPLATE: hook-fee skim (Tier 2, return-delta).
+// Flags required in the address: AFTER_SWAP + AFTER_SWAP_RETURNS_DELTA (0x44).
+// Takes FEE_BPS of the swap's unspecified (usually output) currency for the hook.
+// The owner can withdraw the collected fees.
+//
+// WARNING: a return-delta hook moves the token ledger. A wrong delta or a failed
+// take() reverts every swap and bricks the pool. Always simulate before deploy.
+
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
+import {BalanceDelta, BalanceDeltaLibrary} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+
+contract HookFeeHook {
+    using CurrencyLibrary for Currency;
+    using BalanceDeltaLibrary for BalanceDelta;
+
+    IPoolManager public immutable poolManager;
+    address public immutable owner;
+
+    // hook fee in basis points of the unspecified amount (100 = 1.00%)
+    uint256 public constant FEE_BPS = 100;
+
+    event HookFeeTaken(Currency indexed currency, uint256 amount);
+
+    error NotPoolManager();
+    error NotOwner();
+
+    constructor(IPoolManager _pm) {
+        poolManager = _pm;
+        owner = msg.sender;
+    }
+
+    modifier onlyPoolManager() {
+        if (msg.sender != address(poolManager)) revert NotPoolManager();
+        _;
+    }
+
+    function afterSwap(
+        address,
+        PoolKey calldata key,
+        IPoolManager.SwapParams calldata params,
+        BalanceDelta delta,
+        bytes calldata
+    ) external onlyPoolManager returns (bytes4, int128) {
+        // --- HOOK:LOGIC START ---
+        // pick the unspecified currency + the swapper's delta on it
+        (Currency feeCurrency, int128 unspecifiedAmount) = (params.amountSpecified < 0 == params.zeroForOne)
+            ? (key.currency1, delta.amount1())
+            : (key.currency0, delta.amount0());
+
+        // only skim when the swapper RECEIVES the unspecified currency (positive)
+        if (unspecifiedAmount <= 0) return (IHooks.afterSwap.selector, int128(0));
+
+        uint256 feeAmount = (uint256(uint128(unspecifiedAmount)) * FEE_BPS) / 10_000;
+        if (feeAmount == 0) return (IHooks.afterSwap.selector, int128(0));
+        require(feeAmount <= uint256(uint128(type(int128).max)), "fee overflow");
+
+        poolManager.take(feeCurrency, address(this), feeAmount);
+        emit HookFeeTaken(feeCurrency, feeAmount);
+        return (IHooks.afterSwap.selector, int128(uint128(feeAmount)));
+        // --- HOOK:LOGIC END ---
+    }
+
+    /// @notice Withdraw collected fees for one currency to a recipient.
+    function withdraw(Currency currency, address to, uint256 amount) external {
+        if (msg.sender != owner) revert NotOwner();
+        currency.transfer(to, amount);
+    }
+}

--- a/skills/deploy-uni-hook/templates/MockERC20.sol
+++ b/skills/deploy-uni-hook/templates/MockERC20.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @notice Minimal ERC20 for testnet pools. Public mint, no access control (test only).
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    constructor(string memory _name, string memory _symbol) {
+        name = _name;
+        symbol = _symbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        totalSupply += amount;
+        unchecked {
+            balanceOf[to] += amount;
+        }
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        unchecked {
+            balanceOf[to] += amount;
+        }
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        if (allowed != type(uint256).max) allowance[from][msg.sender] = allowed - amount;
+        balanceOf[from] -= amount;
+        unchecked {
+            balanceOf[to] += amount;
+        }
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}

--- a/skills/deploy-uni-hook/templates/NoOpHook.sol
+++ b/skills/deploy-uni-hook/templates/NoOpHook.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// TEMPLATE: minimal base hook.
+// Flags required in the address: BEFORE_SWAP (0x80).
+// Does nothing but emit an event so you can prove the hook fired. Use this as a
+// clean starting point: add callbacks + flags, then fill the HOOK:LOGIC region.
+
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
+
+contract NoOpHook {
+    IPoolManager public immutable poolManager;
+
+    event BeforeSwapFired(address indexed sender, bool zeroForOne, int256 amountSpecified);
+
+    error NotPoolManager();
+
+    constructor(IPoolManager _pm) {
+        poolManager = _pm;
+    }
+
+    modifier onlyPoolManager() {
+        if (msg.sender != address(poolManager)) revert NotPoolManager();
+        _;
+    }
+
+    function beforeSwap(address sender, PoolKey calldata, IPoolManager.SwapParams calldata params, bytes calldata)
+        external
+        onlyPoolManager
+        returns (bytes4, BeforeSwapDelta, uint24)
+    {
+        // --- HOOK:LOGIC START ---
+        emit BeforeSwapFired(sender, params.zeroForOne, params.amountSpecified);
+        // --- HOOK:LOGIC END ---
+        return (IHooks.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
+    }
+}

--- a/skills/deploy-uni-hook/templates/chains.tsv
+++ b/skills/deploy-uni-hook/templates/chains.tsv
@@ -1,0 +1,33 @@
+# Uniswap v4 chain registry — the SINGLE source of truth for deploy-uni-hook.
+# hook-deploy.sh resolves <chain> here (name -> PoolManager + RPC); the skill reads
+# it to pick a chain and to know the testnet flag for the mainnet double-opt-in.
+# Addresses are the official v4 deployments (developers.uniswap.org/.../v4/deployments).
+# Columns are TAB-separated: name  chainId  testnet  poolManager  stateView  rpc  explorer  alchemy
+# The 8th column (alchemy) is the Alchemy network slug, if any. When ALCHEMY_API_KEY
+# is set, hook-deploy.sh prefers https://<slug>.g.alchemy.com/v2/$ALCHEMY_API_KEY over
+# the public `rpc` (authenticated RPC — matters most for the mainnet sim + broadcast).
+# Set RPC_URL to override the resolved endpoint (testing/escape hatch).
+# To add a chain: append one row. Leave `alchemy` empty if Alchemy has no endpoint.
+#
+# --- mainnets (testnet=false: require arm: + explicit chain: + a balance check) ---
+ethereum	1	false	0x000000000004444c5dc75cB358380D2e3dE08A90	0x7ffe42c4a5deea5b0fec41c94c136cf115597227	https://ethereum-rpc.publicnode.com	https://etherscan.io	eth-mainnet
+unichain	130	false	0x1f98400000000000000000000000000000000004	0x86e8631a016f9068c3f085faf484ee3f5fdee8f2	https://mainnet.unichain.org	https://uniscan.xyz	unichain-mainnet
+optimism	10	false	0x9a13f98cb987694c9f086b1f5eb990eea8264ec3	0xc18a3169788f4f75a170290584eca6395c75ecdb	https://mainnet.optimism.io	https://optimistic.etherscan.io	opt-mainnet
+base	8453	false	0x498581ff718922c3f8e6a244956af099b2652b2b	0xa3c0c9b65bad0b08107aa264b0f3db444b867a71	https://mainnet.base.org	https://basescan.org	base-mainnet
+arbitrum	42161	false	0x360e68faccca8ca495c1b759fd9eee466db9fb32	0x76fd297e2d437cd7f76d50f01afe6160f86e9990	https://arb1.arbitrum.io/rpc	https://arbiscan.io	arb-mainnet
+polygon	137	false	0x67366782805870060151383f4bbff9dab53e5cd6	0x5ea1bd7974c8a611cbab0bdcafcb1d9cc9b3ba5a	https://polygon-bor-rpc.publicnode.com	https://polygonscan.com	polygon-mainnet
+robinhood	4663	false	0x8366a39cc670b4001a1121b8f6a443a643e40951	0xf3334192d15450cdd385c8b70e03f9a6bd9e673b	https://rpc.mainnet.chain.robinhood.com	https://robinhoodchain.blockscout.com
+worldchain	480	false	0xb1860d529182ac3bc1f51fa2abd56662b7d13f33	0x51d394718bc09297262e368c1a481217fdeb71eb	https://worldchain-mainnet.g.alchemy.com/public	https://worldscan.org	worldchain-mainnet
+xlayer	196	false	0x360e68faccca8ca495c1b759fd9eee466db9fb32	0x76fd297e2d437cd7f76d50f01afe6160f86e9990	https://rpc.xlayer.tech	https://www.oklink.com/xlayer
+ink	57073	false	0x360e68faccca8ca495c1b759fd9eee466db9fb32	0x76fd297e2d437cd7f76d50f01afe6160f86e9990	https://rpc-gel.inkonchain.com	https://explorer.inkonchain.com	ink-mainnet
+soneium	1868	false	0x360e68faccca8ca495c1b759fd9eee466db9fb32	0x76fd297e2d437cd7f76d50f01afe6160f86e9990	https://rpc.soneium.org	https://soneium.blockscout.com	soneium-mainnet
+avalanche	43114	false	0x06380c0e0912312b5150364b9dc4542ba0dbbc85	0xc3c9e198c735a4b97e3e683f391ccbdd60b69286	https://api.avax.network/ext/bc/C/rpc	https://snowtrace.io	avax-mainnet
+bnb	56	false	0x28e2ea090877bf75740558f6bfb36a5ffee9e9df	0xd13dd3d6e93f276fafc9db9e6bb47c1180aee0c4	https://bsc-dataseed.binance.org	https://bscscan.com	bnb-mainnet
+celo	42220	false	0x288dc841A52FCA2707c6947B3A777c5E56cd87BC	0xbc21f8720babf4b20d195ee5c6e99c52b76f2bfb	https://forno.celo.org	https://celoscan.io	celo-mainnet
+# --- testnets (testnet=true: the default, dry-run friendly) ---
+# NOTE: Ethereum Sepolia (11155111, PoolManager 0xE03A...3543) is intentionally
+# omitted — its PoolManager predates current v4-core and reverts the fork sim with
+# NativeTransferFailed(), so the gate would block every deploy there anyway.
+base-sepolia	84532	true	0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408	0x571291b572ed32ce6751a2cb2486ebee8defb9b4	https://sepolia.base.org	https://sepolia.basescan.org	base-sepolia
+unichain-sepolia	1301	true	0x00b036b58a818b1bc34d502d3fe730db729e62ac	0xc199f1072a74d4e905aba1a84d9a45e2546b6222	https://sepolia.unichain.org	https://sepolia.uniscan.xyz	unichain-sepolia
+arbitrum-sepolia	421614	true	0xFB3e0C6F74eB1a21CC1Da29aeC80D2Dfe6C9a317	0x9d467fa9062b6e9b1a46e26007ad82db116c67cb	https://sepolia-rollup.arbitrum.io/rpc	https://sepolia.arbiscan.io	arb-sepolia

--- a/skills/deploy-uni-hook/templates/foundry.toml
+++ b/skills/deploy-uni-hook/templates/foundry.toml
@@ -1,0 +1,15 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc = "0.8.26"
+evm_version = "cancun"
+optimizer = true
+optimizer_runs = 800
+via_ir = true
+
+# remappings (also mirror these in remappings.txt):
+#   @uniswap/v4-core/=lib/v4-core/
+#   @uniswap/v4-periphery/=lib/v4-periphery/
+#   v4-periphery/=lib/v4-periphery/
+#   forge-std/=lib/forge-std/src/

--- a/skills/deploy-uni-hook/templates/hook.env.example
+++ b/skills/deploy-uni-hook/templates/hook.env.example
@@ -1,0 +1,14 @@
+# Freeform hook manifest. In freeform mode the skill writes $HOOKBUILD_DIR/hook.env
+# from the prompt; hook-deploy.sh sources it. Base flags are auto-derived from the
+# callbacks in src/Hook.sol — you only declare the two things that can't be inferred.
+
+# Pool LP fee: "dynamic" (hook overrides the fee in beforeSwap) or a number in
+# hundredths of a bip (e.g. 3000 = 0.30%). Default 3000.
+HOOK_POOL_FEE=3000
+
+# Comma list of callbacks that RETURN a non-zero delta (moves the token ledger).
+# Only set these if the callback actually returns a delta, and the address must
+# then also carry the matching *_RETURNS_DELTA flag. Valid:
+#   beforeSwap, afterSwap, afterAddLiquidity, afterRemoveLiquidity
+# Leave empty for the common case.
+HOOK_RETURNS_DELTA=


### PR DESCRIPTION
## Summary

Adds a new self-contained skill under `skills/deploy-uni-hook/` that lets an agent **generate, simulate, audit, and deploy a Uniswap v4 hook** + a demo pool from a one-line brief, on any Uniswap v4 chain (every testnet and mainnet).

- **Pre-audited templates** — `dynamic` (volatility/directional fee), `noop` (minimal starter), `skim` (hook-fee/revenue).
- **Freeform mode** — builds a whole hook from the prompt; hook flags are auto-derived from the callbacks it implements (never hand-set, so they can't drift from code).

## Safety (gates run BEFORE any broadcast)

1. Static audit — contract shape + `onlyPoolManager` on every callback + a dangerous-pattern scan (`selfdestruct`/`delegatecall` hard-fail; `tx.origin`/raw value-call/`assembly` warn).
2. Behavioral `forge test` on a fork — agent-written assertions must pass (and compile).
3. Fork simulation — mines the CREATE2 salt, deploys in-memory, initializes the pool, adds liquidity, runs one swap.

Plus: **dry-run by default** (broadcast only on an explicit `arm:`), **mainnet triple lock** (`arm:` + explicit `chain:` + `HOOK_MAINNET_OK=1`), a funding floor, an optional `MAX_GAS_GWEI` ceiling, and idempotency.

## Trading-rules compliance

Deploys **infrastructure only** (a hook contract + a MockA/MockB demo pool seeded with self-minted mock tokens). It does **not** promote, rate, or recommend any token or asset, and it **never uses or requires a real wallet address** — only a burner deploy key read from the environment inside `hook-deploy.sh` (never printed, never on a command line). A mainnet broadcast risks **gas only**, never real capital.

## Layout

```
skills/deploy-uni-hook/
├── SKILL.md            # agent instructions (grammar, gates, steps, degrade rules)
├── README.md           # install, usage, env vars, deps
├── hook-deploy.sh      # key-safe deploy runner (simulate | broadcast | chains)
├── scripts/setup.sh    # one-time: install Foundry + build the v4 project
└── templates/          # 3 pre-audited hooks + freeform scaffold + behavioral test + chains.tsv
```

- **Dependencies:** Foundry only (installed by `scripts/setup.sh`); no root, no globals beyond `~/.foundry/bin`.
- **Frontmatter:** `name` / `description` / `metadata.version` / `license: MIT` (matches the existing web3 skills).

## Provenance

Ported from the [aeon](https://github.com/aeonfun/aeon) open-source agent framework (author `aeonframework`), where the three templates are pre-validated — each compiles and simulates a full deploy + swap on Base Sepolia. MIT licensed.