### PR TITLE
Add Spot Signal Scout skill

### DIFF
--- a/skills/binance-web3/spot-signal-scout/LICENSE
+++ b/skills/binance-web3/spot-signal-scout/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ZaheerBabar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/binance-web3/spot-signal-scout/README.md
+++ b/skills/binance-web3/spot-signal-scout/README.md
@@ -1,0 +1,27 @@
+# Spot Signal Scout
+
+Read-only AI research skill for cryptocurrency Spot-market setup analysis.
+
+## What it does
+
+Spot Signal Scout identifies market regime and common Spot setups, scores structure, volume, momentum, confirmation, risk/reward, and market quality, then separates score from confidence and decision state.
+
+Possible states are `CONFIRMED SETUP`, `WAIT FOR CONFIRMATION`, `WATCH`, `NO TRADE`, and `AVOID`.
+
+## What it does not do
+
+- Place, modify, or cancel orders
+- Execute trades
+- Request withdrawal permissions
+- Request seed phrases or private keys
+- Guarantee profits or outcomes
+
+## Data
+
+The skill is an analytical layer. It requires current or sufficiently recent market data from the agent's available market-data capabilities. If reliable data is unavailable, it must not fabricate values and should return an insufficient-data result.
+
+## Example requests
+
+- Scan BTCUSDT, ETHUSDT and SOLUSDT on 4H for Spot setups.
+- Analyze BTCUSDT for a breakout.
+- Rank these Spot pairs and tell me which are only watchlist candidates.

--- a/skills/binance-web3/spot-signal-scout/SKILL.md
+++ b/skills/binance-web3/spot-signal-scout/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: spot-signal-scout
+title: Spot Signal Scout
+description: Read-only AI research skill for screening and ranking cryptocurrency Spot setups using market regime, structure, volume, momentum, confirmation, risk/reward, liquidity, and data-quality checks. Use when a user asks to scan, compare, rank, or analyze Spot market setups. Never executes trades.
+version: 0.1.0
+license: MIT
+metadata:
+  version: 0.1.0
+  author: ZaheerBabar
+---
+
+# Spot Signal Scout
+
+## Purpose
+
+Analyze cryptocurrency Spot-market setups and return a ranked, explainable research report.
+
+The skill is **read-only**. It must never place, modify, cancel, or simulate an order as if it were executed. It must never request withdrawal permissions, private keys, seed phrases, or unrestricted trading credentials.
+
+Use this skill when the user asks to:
+- scan multiple Spot pairs for setups
+- rank Spot opportunities
+- analyze a specific Spot pair
+- evaluate a breakout, pullback, momentum, or range setup
+- determine whether a setup is confirmed or still needs confirmation
+- explain why no valid setup exists
+
+Do not use it to execute trades.
+
+## Data integrity
+
+Before analysis:
+1. Identify the exact Spot pair and timeframe.
+2. Use the freshest available market data from the connected environment.
+3. State data freshness when available.
+4. Never invent price, volume, OHLCV, support, resistance, indicator, liquidity, or target values.
+5. If required data is unavailable or materially stale, say so.
+6. Never turn missing data into a positive signal.
+7. Never claim data is live unless the source actually provides current data.
+
+If reliable market data cannot be obtained, return:
+
+`INSUFFICIENT DATA — NO RELIABLE SETUP`
+
+## Market regime
+
+Assess the broader regime before ranking individual setups:
+- `BULLISH TREND`
+- `BEARISH TREND`
+- `RANGE`
+- `TRANSITION`
+- `UNCLEAR`
+
+Use observable structure and participation. Do not infer a regime from one indicator alone.
+
+## Setup types
+
+Classify the setup when evidence supports it:
+- `BREAKOUT`
+- `BREAKOUT RETEST`
+- `TREND PULLBACK`
+- `MOMENTUM CONTINUATION`
+- `RANGE REVERSAL`
+- `WATCHLIST`
+
+A developing setup must not be presented as confirmed.
+
+## Six-factor score
+
+Calculate a score from 0 to 100:
+
+| Factor | Maximum |
+|---|---:|
+| Market Structure | 25 |
+| Volume & Participation | 20 |
+| Momentum | 15 |
+| Confirmation & Volatility | 15 |
+| Risk/Reward | 15 |
+| Liquidity & Market Quality | 10 |
+| **Total** | **100** |
+
+### 1. Market Structure — 25
+
+Evaluate trend direction, higher-high/higher-low or lower-high/lower-low behavior, consolidation quality, support/resistance, and structural clarity.
+
+- 21–25: very clear
+- 16–20: good
+- 11–15: mixed/developing
+- 6–10: weak
+- 0–5: unreliable
+
+### 2. Volume & Participation — 20
+
+Evaluate relative volume, breakout volume, participation expansion, and whether price movement is supported by meaningful activity.
+
+- 17–20: strong
+- 13–16: good
+- 9–12: mixed
+- 5–8: weak
+- 0–4: contradictory/absent
+
+### 3. Momentum — 15
+
+Evaluate directional momentum and momentum behavior. RSI or other oscillators may support the assessment but must not be interpreted mechanically.
+
+Never assume overbought = sell or oversold = buy.
+
+- 13–15: strong/constructive
+- 10–12: good
+- 7–9: neutral
+- 4–6: weak
+- 0–3: contradictory
+
+### 4. Confirmation & Volatility — 15
+
+Evaluate breakout acceptance, closing behavior, rejection, volatility expansion, and false-breakout risk.
+
+- 13–15: strong confirmation
+- 10–12: good
+- 7–9: developing
+- 4–6: weak
+- 0–3: unconfirmed/high risk
+
+### 5. Risk/Reward — 15
+
+Define a defensible trigger, invalidation, and target. Preferred minimum R:R: `2.0:1`. R:R below `1.5:1` should normally be rejected from the primary ranked list unless the user explicitly asks for lower-R:R setups. Never create unrealistic targets solely to improve R:R.
+
+### 6. Liquidity & Market Quality — 10
+
+Evaluate available evidence for liquidity, spread/depth where available, abnormal price behavior, and market-data reliability. Do not treat an illiquid pair as equivalent to a highly liquid major pair.
+
+## Score labels
+
+- `90–100`: EXCEPTIONAL
+- `80–89`: STRONG
+- `70–79`: WATCH
+- `60–69`: WEAK
+- `<60`: AVOID
+
+The score measures research quality. It is not a probability of profit and is not a guarantee.
+
+## Hard rejection rules
+
+A setup cannot be confirmed when:
+1. Data is materially stale or unreliable.
+2. Invalidation cannot be defined.
+3. R:R is clearly inadequate.
+4. Liquidity is materially poor.
+5. The breakout lacks credible structural evidence.
+6. Evidence is materially contradictory.
+7. Price is excessively extended from the logical trigger.
+8. Required data is missing.
+9. The pair cannot be verified as the requested Spot market.
+
+A hard rejection overrides a high raw score.
+
+## Decision state
+
+Keep score, confidence, and decision state separate.
+
+### CONFIRMED SETUP
+All must be true:
+- score >= 80
+- structure >= 16/25
+- volume >= 10/20
+- confirmation >= 10/15
+- R:R >= 2.0:1
+- acceptable liquidity/market quality
+- adequate data freshness
+- no hard rejection
+
+### WAIT FOR CONFIRMATION
+Use when:
+- score >= 70
+- structure is valid
+- setup is developing
+- required trigger/confirmation has not occurred
+
+### WATCH
+Use for a developing setup with a clearly identifiable future condition, including borderline setups that do not yet meet confirmation requirements.
+
+### NO TRADE
+Use when:
+- a hard rejection applies
+- R:R is inadequate
+- evidence is materially contradictory
+- market is too unclear
+- setup is excessively extended
+- data quality is insufficient
+
+### AVOID
+Use for low-quality conditions that are not worth monitoring.
+
+Never force a fixed number of winners. If no setup qualifies, return `NO VALID SETUP FOUND`.
+
+## Confirmation rules
+
+A high score does not automatically mean confirmation.
+
+For breakouts, evaluate:
+- meaningful resistance
+- consolidation/compression where relevant
+- breakout attempt
+- closing acceptance
+- volume participation
+- immediate rejection
+- retest behavior where available
+
+If the trigger has not occurred, use `WAIT FOR CONFIRMATION`.
+
+For pullbacks, require evidence that the trend is actually resuming rather than assuming continuation.
+
+## False-breakout protection
+
+Flag `LOW CONFIRMATION`, `HIGH FALSE-BREAKOUT RISK`, or `WAIT FOR RETEST` when appropriate.
+
+A large candle or large volume spike alone is not sufficient confirmation.
+
+## Pump/spike protection
+
+If price has moved unusually far in a short period:
+- assess extension from support
+- assess volatility
+- assess volume quality
+- assess candle structure
+- assess liquidity
+- assess whether R:R remains realistic
+
+Possible verdict: `EXTENDED — WAIT FOR REASSESSMENT`.
+
+Do not label vertical price expansion as a high-quality momentum setup automatically.
+
+## Conflict detection
+
+Structure has priority over isolated indicators.
+
+Example: if an oscillator is bullish while market structure remains bearish, report `Momentum positive, structure bearish — conflict detected.`
+
+Do not average contradictory evidence into artificial confidence.
+
+## Confidence
+
+Confidence is independent of the score:
+- `HIGH`: strong data quality, clear structure, strong confirmation, limited contradiction
+- `MEDIUM-HIGH`: strong setup with one meaningful uncertainty
+- `MEDIUM`: promising but incomplete evidence
+- `LOW`: speculative, weakly confirmed, or materially uncertain
+
+A

--- a/skills/binance-web3/spot-signal-scout/examples/breakout.md
+++ b/skills/binance-web3/spot-signal-scout/examples/breakout.md
@@ -1,0 +1,5 @@
+# Breakout Example
+
+A breakout should be assessed using meaningful resistance, consolidation where relevant, breakout attempt, closing acceptance, volume participation, false-breakout risk, retest behavior where available, logical invalidation, defensible target, and R:R.
+
+A breakout candle alone is not sufficient for a confirmed setup.

--- a/skills/binance-web3/spot-signal-scout/examples/false-breakout.md
+++ b/skills/binance-web3/spot-signal-scout/examples/false-breakout.md
@@ -1,0 +1,3 @@
+# False Breakout Example
+
+If price briefly moves above resistance but closes back inside the prior range without convincing acceptance, do not call the breakout confirmed. Reduce confirmation, flag false-breakout risk when appropriate, and use `WAIT FOR RETEST` or `NO TRADE` when justified.

--- a/skills/binance-web3/spot-signal-scout/examples/trend-pullback.md
+++ b/skills/binance-web3/spot-signal-scout/examples/trend-pullback.md
@@ -1,0 +1,3 @@
+# Trend Pullback Example
+
+For a pullback, verify that higher-high/higher-low structure remains intact, assess the quality of the retracement, look for evidence of renewed demand, and define invalidation below meaningful structure. Do not assume continuation merely because the asset was previously bullish.

--- a/skills/binance-web3/spot-signal-scout/references/decision-rules.md
+++ b/skills/binance-web3/spot-signal-scout/references/decision-rules.md
@@ -1,0 +1,18 @@
+# Decision Rules
+
+Priority order:
+
+1. Data validity
+2. Hard rejection rules
+3. Market regime
+4. Structure
+5. Volume/participation
+6. Momentum
+7. Confirmation
+8. Risk/reward
+9. Liquidity
+10. Score
+11. Confidence
+12. Decision state
+
+Do not average contradictory evidence into false confidence.

--- a/skills/binance-web3/spot-signal-scout/references/output-format.md
+++ b/skills/binance-web3/spot-signal-scout/references/output-format.md
@@ -1,0 +1,11 @@
+# Output Format
+
+A scan should contain:
+
+1. Market snapshot
+2. Ranked setup table
+3. Detailed top setup
+4. Key risks
+5. Final decision state
+
+A no-trade result should explain why the setup failed and what future condition would justify reassessment.

--- a/skills/binance-web3/spot-signal-scout/references/scoring-model.md
+++ b/skills/binance-web3/spot-signal-scout/references/scoring-model.md
@@ -1,0 +1,13 @@
+# Scoring Model
+
+| Factor | Maximum |
+|---|---:|
+| Market Structure | 25 |
+| Volume & Participation | 20 |
+| Momentum | 15 |
+| Confirmation & Volatility | 15 |
+| Risk/Reward | 15 |
+| Liquidity & Market Quality | 10 |
+| **Total** | **100** |
+
+A score of 80+ is not enough by itself for confirmation. Confirmation also requires adequate structure, volume, confirmation evidence, R:R >= 2.0, acceptable liquidity, adequate data freshness, and no hard rejection.

--- a/skills/community/binance-margin-risk-guard/README.md
+++ b/skills/community/binance-margin-risk-guard/README.md
@@ -1,0 +1,13 @@
+# Binance Margin Risk Guard
+
+> Real-time liquidation distance, margin health scoring, and portfolio stress-testing for Binance Cross & Isolated Margin accounts.
+
+`binance-margin-risk-guard` is an MCP-compatible skill designed for AI agents operating on the Binance Skills Hub. It enables conversational agents to evaluate account safety ratios, simulate market drawdowns, and model pre-trade margin impacts without making state-changing transactions.
+
+## Features
+- **Margin Health Scoring**: Categorizes account status into Safe (>2.0), Moderate (1.5–2.0), Critical (1.1–1.5), and Liquidation Risk (<1.1).
+- **Downside Stress Testing**: Models -10% and -20% instant market crash scenarios across collateral assets.
+- **Pre-Trade Impact Analysis**: Calculates how taking on additional leverage alters account health before executing trades.
+
+## License
+[MIT License](LICENSE)

--- a/skills/community/binance-margin-risk-guard/SKILL.md
+++ b/skills/community/binance-margin-risk-guard/SKILL.md
@@ -1,0 +1,38 @@
+---
+title: binance-margin-risk-guard
+description: Calculates real-time liquidation distance, margin health ratio, and maximum stress-tested drawdowns for Binance Cross & Isolated Margin accounts. Use when users ask about margin health, liquidation price risk, leverage safety, or position sizing.
+metadata:
+  version: 1.0.0
+  author: AlphaZolo
+  license: MIT
+  tags:
+    - binance
+    - margin-trading
+    - risk-management
+    - liquidation-guard
+---
+
+# Binance Cross-Margin Risk & Liquidation Guard
+
+## Purpose & Use Case
+Automates position-level risk analysis before trade execution. Instead of manually calculating liquidation thresholds across collateral assets, this skill computes exact safety buffers and models price crash scenarios.
+
+## When to Use
+Trigger this skill when the user asks to:
+- Check current Binance margin level or liquidation proximity.
+- Calculate potential liquidation price for a prospective margin position.
+- Model stress test scenarios (e.g., "What happens to my margin level if ETH drops 15%?").
+
+## Workflow & Calculations
+1. **Calculate Margin Level**:
+   $$\text{Margin Level} = \frac{\text{Total Collateral Value}}{\text{Total Liability Value}}$$
+2. **Status Classification**:
+   - **Margin Level > 2.0**: Safe (Low Risk)
+   - **1.5 - 2.0**: Moderate (Caution)
+   - **1.1 - 1.5**: Critical (High Liquidation Risk)
+   - **< 1.1**: Forced Liquidation Warning
+3. **Stress Test**: Apply -10% and -20% market shocks to collateral assets to compute projected margin health.
+
+## Security & Guardrails
+- Read-only simulation mode; no trade execution or asset transfer capabilities.
+- Emits critical warnings when Margin Level drops below 1.30.


### PR DESCRIPTION
# Summary

This Pull Request contributes two read-only, MCP-compatible community research and risk skills:

1. **Spot Signal Scout** (`skills/binance-web3/spot-signal-scout/`)
   - Read-only AI research skill for screening, ranking, and evaluating cryptocurrency Spot-market setups with explainable decision states.
2. **Binance Margin Risk Guard** (`skills/community/binance-margin-risk-guard/`)
   - Real-time liquidation distance calculator, margin health ratio scorer, and downside stress-testing tool for Cross & Isolated Margin accounts.

# APIs Used

None directly bundled with the skills. They rely on the agent's existing/connected market-data capabilities (e.g., Spot price, volume, OHLCV data) to perform their analysis — they do not call any exchange API directly and do not require API keys.

# Binaries Used

None. These are pure documentation/instruction-based skills (Markdown files only) with no scripts or external binaries.

# How It Works

### 1. Spot Signal Scout
The skill instructs the AI agent to:
1. Identify the Spot pair and timeframe requested.
2. Pull available market data from the agent's environment.
3. Assess market regime, classify setup types, and score weighted factors (0-100).
4. Assign a confidence level and final decision state (CONFIRMED SETUP, WAIT FOR CONFIRMATION, WATCH, NO TRADE, AVOID).

### 2. Binance Margin Risk Guard
The skill instructs the AI agent to:
1. Calculate account-level Margin Ratios ($\text{Total Collateral} / \text{Total Liabilities}$).
2. Categorize account safety into status brackets (Safe >2.0, Moderate 1.5–2.0, Critical 1.1–1.5, Liquidation <1.1).
3. Execute instant downside market shock stress tests (-10%, -20%) across collateral assets.

# Security & Compliance

- Both skills strictly operate in read-only simulation mode (no private state mutation, order execution, or asset transfers).
- Neither skill requests private keys, seed phrases, or exchange credentials.