### PR TITLE
Add Korean crypto market intelligence skills (kimchi premium, arbitrage, sentiment)

### DIFF
--- a/skills/printmoneylab/kimchi-premium-arbitrage/SKILL.md
+++ b/skills/printmoneylab/kimchi-premium-arbitrage/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: kimchi-premium-arbitrage
+description: |
+  Real-time Kimchi Premium and Korea-vs-global price spread data for trading
+  agents. Covers per-token premium (Upbit vs Binance global reference price,
+  both official USD/KRW basis and USDT real-trade basis), a full cross-exchange
+  scanner over every symbol shared by Upbit and Binance (fetched live — new
+  listings appear automatically), reverse premiums (Korean discount), stablecoin
+  premium as a capital-flow gauge, USD/KRW FX rate, Korean exchange prices, and
+  real-time listing/warning alerts from Upbit and Bithumb.
+  Trigger whenever the user or agent mentions: kimchi premium, Korean premium,
+  Korea arbitrage, Upbit vs Binance spread, reverse premium, Korean exchange
+  prices, stablecoin premium in Korea, KRW crypto, 김치프리미엄, 김프, 업비트,
+  빗썸 — even if they don't say "premium" explicitly.
+  Powered by KR Crypto Intelligence (api.printmoneylab.com) — Korean-language
+  market data processed into English for global agents.
+metadata:
+  version: 1.0.0
+  author: bakyang2
+license: MIT
+---
+
+# Kimchi Premium & Korea Arbitrage — Korean Market Data Layer
+
+Korean crypto markets trade at persistent, measurable spreads against global
+venues. This skill gives an agent read-only access to that data in English.
+It is **additive to Binance execution, not a competitor**: the premium itself
+is computed **against Binance as the global reference price**, so this skill is
+the Korea-side context layer an agent reads before routing execution through
+Binance Skills Hub.
+
+Read-only market data. This skill never places orders, never holds funds, and
+never recommends buying or selling any specific asset.
+
+## What is the Kimchi Premium (background)
+
+The Kimchi Premium is the percentage difference between a token's price on
+Korean exchanges (Upbit, Bithumb — quoted in KRW) and its price on global
+venues, converted at the USD/KRW rate. It reflects Korean retail flow,
+capital-control friction, and local demand cycles. Two bases matter:
+
+- **Official-FX basis** — uses the official USD/KRW rate. This is the number
+  usually quoted in media.
+- **USDT real-trade basis** — uses the actual USDT/KRW rate on Korean
+  exchanges. This is the spread that is actionable in practice, because USDT
+  is the settlement leg most flows really use.
+
+A related gauge is the **stablecoin premium**: when USDT/USDC trade above the
+official FX rate on Korean exchanges, capital is flowing into the Korean
+crypto market; below it, flowing out.
+
+## Connection
+
+MCP endpoint (streamable HTTP, stateless):
+
+```
+https://mcp.printmoneylab.com/mcp
+```
+
+Add the server to any MCP-compatible agent (Claude Code, OpenClaw, LangChain,
+custom stacks). Connecting, listing tools, and discovering what each tool
+returns is free. Each data tool responds with its own usage metadata on first
+call, so the agent learns everything it needs at runtime — no keys to
+configure in advance. For attribution, optionally send the header
+`X-KRC-Source: binance-skills-hub` on calls.
+
+## Tools
+
+| Tool | What it returns |
+|---|---|
+| `get_available_symbols` | Live list of symbols on Upbit / Bithumb and the Upbit–Binance common set (free; fetched live from exchange listings, so new listings appear automatically) |
+| `check_health` | Service liveness (free) |
+| `get_kimchi_premium` | Per-token premium vs the Binance global price — both official-FX and USDT bases, with direction |
+| `get_arbitrage_scanner` | Full scan across every Upbit–Binance shared symbol: per-token premiums, reverse premiums (Korean discount), Upbit–Bithumb gaps, market-share split. 60s cadence |
+| `get_stablecoin_premium` | USDT / USDC premium on Korean exchanges vs official FX — capital-flow gauge |
+| `get_fx_rate` | USD/KRW rate used as the premium denominator |
+| `get_kr_prices` | Raw KRW quotes from Upbit and Bithumb |
+| `get_exchange_alerts` | New listings, delistings, investment warnings, caution flags from Upbit/Bithumb. 60s cadence |
+| `get_market_movers` | 1-minute price surges, volume spikes, top-volume tokens on Korean venues |
+
+## When to call
+
+- **Before routing a cross-venue trade** — read the per-token premium
+  (`get_kimchi_premium`) or the full scanner to see where the Korea-global
+  spread sits right now.
+- **Capital-flow regime check** — `get_stablecoin_premium` as a fast gauge of
+  money moving into or out of the Korean market.
+- **Listing-event awareness** — `get_exchange_alerts` before acting on a token
+  that may carry an Upbit/Bithumb investment warning.
+- **Korea-side momentum** — `get_market_movers` for 1-minute surges that often
+  lead Korean retail flow.
+
+## Example
+
+```
+get_kimchi_premium(symbol="BTC")
+```
+
+Returns (abridged):
+
+```json
+{
+  "symbol": "BTC",
+  "upbit_krw": 91416000,
+  "binance_usdt": 64980,
+  "fx_rate": 1409.64,
+  "usdt_krw_rate": 1408.0,
+  "premium_percent": -0.2,
+  "premium_pct_usdt": -0.08,
+  "premium_direction": "negative"
+}
+```
+
+Values are live market data, not signals. Interpretation and any trading
+decision remain with the agent and its own policy.
+
+## Notes
+
+- Data sources: Upbit and Bithumb public APIs (real-time), Binance global
+  price as the reference leg, official FX feed.
+- All output is factual market data in English; no asset is presented as
+  guaranteed, safe, or recommended.
+- Micropayment-enabled tools state their own terms in-band (x402 over Base,
+  Polygon, or Solana); the skill document itself carries no payment details.
+  

--- a/skills/printmoneylab/korean-market-sentiment/SKILL.md
+++ b/skills/printmoneylab/korean-market-sentiment/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: korean-market-sentiment
+description: |
+  Korean crypto market sentiment and context in English, for agents that
+  cannot read Korean-language sources. Fuses Korean crypto news (Coinness,
+  6-hour window) with live Upbit/Bithumb exchange signals (deposit surges,
+  volume spikes, investment warnings, premium extremes) into a structured
+  sentiment read; adds per-token Korea-vs-global divergence interpretation,
+  a full multi-source Korean market read, and a KRW macro stress score
+  (US rates, VIX, foreign-investor flow proxy, KRW momentum, semiconductors).
+  Trigger whenever the user or agent mentions: Korean market sentiment, Korea
+  crypto mood, Korean retail, Korean crypto news, Korea vs global divergence,
+  KRW macro, won stress, 한국 시장 심리, 한국 코인 뉴스, 원화 — even without
+  the word "sentiment".
+  Powered by KR Crypto Intelligence (api.printmoneylab.com) — Korean-language
+  sources processed into English for global agents.
+metadata:
+  version: 1.0.0
+  author: bakyang2
+license: MIT
+---
+
+# Korean Market Sentiment — Korea Context Layer for Trading Agents
+
+Korean retail flow is a distinct force in crypto: it concentrates on Korean
+exchanges, reacts to Korean-language news, and frequently moves before or
+against global venues. Most agents are blind to it because the sources are in
+Korean. This skill is the **Korea-side context ("brain") layer**: an agent
+reads the sentiment and divergence picture here, then executes wherever its
+policy dictates — pairing naturally with Binance Skills Hub for the execution
+leg, since divergence is measured against Binance-referenced global prices.
+
+Read-only analysis of public market data and news. This skill never places
+orders and never recommends buying or selling any specific asset.
+
+## Why Korean sentiment matters (background)
+
+- Korean exchanges quote in KRW with a persistent premium/discount vs global
+  prices (the Kimchi Premium), so Korean sentiment shows up directly in
+  price spreads, not only in social chatter.
+- Exchange behavior — deposit surges, volume spikes, investment-warning
+  flags — is itself a sentiment signal unique to the Korean market structure.
+- Korean-language news (e.g., Coinness) moves this flow, and is largely
+  invisible to non-Korean-speaking agents. This skill translates and
+  structures that context into English.
+
+## Connection
+
+MCP endpoint (streamable HTTP, stateless):
+
+```
+https://mcp.printmoneylab.com/mcp
+```
+
+Works with any MCP-compatible agent (Claude Code, OpenClaw, LangChain, custom
+stacks). Connecting and tool discovery are free; each tool responds with its
+own usage metadata in-band, so no advance configuration is needed. For
+attribution, optionally send the header `X-KRC-Source: binance-skills-hub`.
+
+## Tools
+
+| Tool | What it returns |
+|---|---|
+| `get_kr_sentiment` | Structured Korean market sentiment in English: label + score, key exchange signals (deposit/volume surges, warnings, premium extremes), and Korean news context from a 6-hour window |
+| `get_global_vs_korea_divergence` | Per-token Korea-vs-global price divergence with a short interpretation (25 majors) |
+| `get_global_vs_korea_divergence_deep` | Divergence plus 24h Korean news signals (keywords, sentiment score) and a structured analysis: Korean market drivers, global context, confidence |
+| `get_market_read` | Full Korean market read merging 12+ sources: premium, stablecoin flow, volume leaders, funding, open interest, dominance, Fear & Greed, exchange intelligence — returned as signal, confidence, key factors, token alerts, risk warning |
+| `get_krw_macro_stress` | KRW macro stress score (0–100): US 3Y rate stress, VIX, foreign-investor flow proxy, KRW momentum, Korean semiconductor equity — rolling-percentile model with per-component breakdown |
+| `get_available_symbols` | Live symbol coverage (free) |
+| `check_health` | Service liveness (free) |
+
+## When to call
+
+- **Before acting on a Korea-originated move** — `get_kr_sentiment` to see
+  whether Korean retail is driving it and in which direction.
+- **Per-token decision context** — `get_global_vs_korea_divergence` (or the
+  deep variant when news context matters) for one symbol's Korea-vs-global
+  picture.
+- **Daily regime brief** — `get_market_read` as a single consolidated Korean
+  market snapshot instead of polling many sources.
+- **Macro filter** — `get_krw_macro_stress` when strategy should adjust to
+  KRW-level stress rather than token-level noise.
+
+## Example
+
+```
+get_kr_sentiment()
+```
+
+Returns (abridged):
+
+```json
+{
+  "sentiment": "CAUTIOUS_FOMO",
+  "score": 0.4,
+  "report_en": "Korean retail showing mixed signals with reverse premiums on select tokens while deposit activity surges for mid-cap alts.",
+  "exchange_signals": {
+    "deposit_soaring": ["..."],
+    "warnings": 2,
+    "avg_premium_pct": 0.3
+  },
+  "news_context": {"total_analyzed": 20, "korean_count": 8}
+}
+```
+
+Output is descriptive context, not advice. Any trading decision remains with
+the agent and its own risk policy.
+
+## Notes
+
+- Sources: Coinness (Korean crypto news), Upbit and Bithumb public APIs,
+  global reference feeds; AI synthesis produces factual English summaries
+  with no recommendations.
+- All content is neutral and educational; no asset is presented as
+  guaranteed, safe, or recommended.
+- Micropayment-enabled tools state their own terms in-band (x402 over Base,
+  Polygon, or Solana); the skill document itself carries no payment details.


### PR DESCRIPTION
# Summary

Two read-only skills under `skills/printmoneylab/` that give agents access to Korean crypto market data in English — a market segment otherwise invisible to non-Korean-speaking agents:

- **kimchi-premium-arbitrage** — real-time Kimchi Premium per token (computed against Binance as the global reference price, on both official-FX and USDT bases), a full scanner across every Upbit–Binance shared symbol (fetched live, new listings appear automatically), reverse premiums, stablecoin premium as a capital-flow gauge, USD/KRW FX rate, Korean exchange prices, and listing/warning alerts.
- **korean-market-sentiment** — structured Korean market sentiment in English (Korean news + live Upbit/Bithumb exchange signals), per-token Korea-vs-global divergence with interpretation, a consolidated multi-source Korean market read, and a KRW macro stress score.

Complementary to Binance execution, not competing: the premium itself is measured against the Binance global price, so these skills are the Korea-side context layer an agent reads before routing execution through Binance skills.

# APIs Used

Both skills use a single MCP endpoint (streamable HTTP, stateless). Connection and tool discovery are free; each tool returns its own usage metadata in-band at runtime.

HTTP Info | Description | Required Parameters | Optional Parameters | Authentication
--------- | ----------- | ------------------- | ------------------- | -------------
MCP https://mcp.printmoneylab.com/mcp | MCP server exposing the tools below | None (standard MCP initialize handshake) | None | None (connection and discovery are free)

Tools exposed by the endpoint:

Tool | Description
---- | -----------
get_available_symbols | Live symbol list on Upbit/Bithumb and the Upbit–Binance common set (free; fetched live from exchange listings)
check_health | Service liveness (free)
get_kimchi_premium | Per-token premium vs the Binance global price (official-FX and USDT bases)
get_arbitrage_scanner | Full scan across every Upbit–Binance shared symbol: premiums, reverse premiums, Upbit–Bithumb gaps
get_stablecoin_premium | USDT/USDC premium on Korean exchanges vs official FX (capital-flow gauge)
get_fx_rate | USD/KRW rate used as the premium denominator
get_kr_prices | Raw KRW quotes from Upbit and Bithumb
get_exchange_alerts | New listings, delistings, investment warnings from Upbit/Bithumb
get_market_movers | 1-minute surges, volume spikes, top-volume tokens on Korean venues
get_kr_sentiment | Structured Korean market sentiment in English (news + exchange signals)
get_global_vs_korea_divergence | Per-token Korea-vs-global divergence with interpretation (deep variant adds 24h Korean news signals)
get_market_read | Consolidated Korean market read merging 12+ sources
get_krw_macro_stress | KRW macro stress score (0–100) with per-component breakdown

Underlying data sources: Upbit and Bithumb public APIs (real-time), Binance global price as the reference leg, official FX feed, Coinness Korean crypto news.

# Binaries Used

None. Both skills are pure documentation: they instruct the agent to connect to a standard MCP endpoint. No installation, no CLI, no local scripts, no root access, no external dependencies.

# How it works

1. The agent adds the MCP server (`https://mcp.printmoneylab.com/mcp`, streamable HTTP) — works with any MCP-compatible runtime (Claude Code, OpenClaw, LangChain, custom stacks).
2. Tool discovery via the standard MCP handshake is free and requires no keys or configuration.
3. The agent calls a tool. Free tools (`get_available_symbols`, `check_health`) return data directly. Data tools respond in-band with their own usage metadata on first call, so the agent learns everything it needs at runtime — the skill documents themselves carry no payment details and no wallet addresses.
4. All output is read-only, factual market data in English. The skills never place orders, never hold funds, and never present any asset as guaranteed, safe, or recommended; interpretation and any trading decision remain with the agent and its own policy.
5. For attribution, calls may optionally include the header `X-KRC-Source: binance-skills-hub`.

# Use Cases

- **Pre-trade Korea context**: before routing a cross-venue trade, read the per-token Kimchi Premium or the full Upbit–Binance scanner to see where the Korea-global spread sits right now, then execute via Binance skills.
- **Capital-flow regime check**: use the stablecoin premium as a fast gauge of money flowing into or out of the Korean crypto market.
- **Listing-event awareness**: check Upbit/Bithumb investment warnings and new listings before acting on a token.
- **Korea-originated moves**: when a token surges, read Korean market sentiment to see whether Korean retail is driving it and in which direction.
- **Daily market brief**: one consolidated Korean market read instead of polling many Korean-language sources.
- **Macro filter**: adjust strategy to KRW-level stress (rates, VIX, foreign-investor flow, FX momentum) rather than token-level noise.