### PR TITLE
Add offline x402 offer receipt verifier

### DIFF
--- a/skills/x402-offer-receipt-verifier/.gitignore
+++ b/skills/x402-offer-receipt-verifier/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/skills/x402-offer-receipt-verifier/README.md
+++ b/skills/x402-offer-receipt-verifier/README.md
@@ -1,0 +1,78 @@
+# x402 Offer Receipt Verifier
+
+A fixture-only reference skill and offline CLI for verifying receipts from the official x402 `offer-receipt` extension. It supports EIP-712 and compact JWS receipts while keeping cryptographic validity distinct from trust authorization.
+
+The CLI does not connect a wallet, resolve a DID, query a blockchain, submit a payment, or make a network request. Dependency installation can require package-registry access.
+
+## Requirements
+
+- Node.js 20 or newer
+- npm
+
+Install the pinned dependencies without lifecycle scripts:
+
+```bash
+npm ci --ignore-scripts
+```
+
+Runtime verification uses `@x402/extensions` 2.23.0, the official Apache-2.0 x402 extension package. The direct `viem` development dependency is used by the EIP-712 fixture generator.
+
+## Verify a Receipt
+
+Create a JSON input using [references/input-format.md](references/input-format.md), then run:
+
+```bash
+node scripts/verify-receipt.mjs --input path/to/input.json
+```
+
+Run commands from this skill directory. For a copy-paste JWS smoke test:
+
+```bash
+npm run verify:jws
+```
+
+Exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Every configured check passed |
+| `1` | The input file could not be read or parsed |
+| `2` | Verification completed and at least one check failed |
+
+The result reports these checks independently:
+
+| Check | What it establishes |
+| --- | --- |
+| `schema` | The signed payload uses version 1 and the supported strict fields |
+| `signature` | The signature is cryptographically valid |
+| `authorization` | The recovered signer or JWS `kid` matches explicit trust policy |
+| `freshness` | `issuedAt` is within the configured age and clock-skew window |
+| `binding` | Resource URL, network, and payer exactly match caller expectations |
+| `transaction` | A signed transaction reference is present or equals an expected value |
+
+Trust anchors and expected bindings must come from a source independent of the receipt. An attacker-controlled input file can replace its own `trust` or `policy` section, so do not treat an arbitrary bundled file as self-authenticating.
+
+## Fixtures and Tests
+
+Regenerate the deterministic fixtures and run the tests:
+
+```bash
+npm run fixtures
+npm test
+```
+
+The generator rewrites the two tracked JWS fixtures and writes its EIP-712 fixture only to a newly created system temporary directory, whose path it prints. The tests also keep EIP-712 material in memory or temporary files and remove verifier inputs after each case. No wallet address is stored in a tracked fixture or test literal.
+
+All fixtures use reserved `.test` names and reproducible test-only signing material. They are not production identities and must never receive funds or be used as trust anchors.
+
+## Limitations
+
+- No remote DID resolution
+- No chain lookup or settlement proof
+- No proof of the response body's contents or quality
+- No proof of amount, asset, or destination beyond fields present in the signed extension payload
+
+Protocol references:
+
+- [x402 offer and receipt documentation](https://docs.x402.org/extensions/offer-receipt)
+- [x402 offer and receipt specification used for this prototype](https://github.com/x402-foundation/x402/blob/230e6a9a7eebce22c911a0687d6f4e6d1ac019f7/specs/extensions/extension-offer-and-receipt.md)

--- a/skills/x402-offer-receipt-verifier/SKILL.md
+++ b/skills/x402-offer-receipt-verifier/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: x402-offer-receipt-verifier
+description: Verify x402 offer-receipt artifacts offline when a user supplies an EIP-712 or JWS receipt plus independently trusted public verification policy. Use for signature, signer or kid authorization, freshness, resource binding, and transaction-reference checks. Do not use to make payments or claim settlement or response quality.
+version: 0.1.0
+license: MIT
+metadata:
+  author: JasonColapietro
+  version: 0.1.0
+---
+
+# x402 Offer Receipt Verifier
+
+Verify an x402 `offer-receipt` artifact without connecting a wallet, resolving a DID, or querying a blockchain.
+
+Run commands from the directory containing this `SKILL.md`. The scripts require Node.js 20 or newer and npm. A first-time dependency install can access the npm registry; receipt verification itself makes no network request.
+
+## Workflow
+
+1. Identify whether the receipt uses `eip712` or `jws`.
+2. Obtain trust anchors and expected bindings from a source independent of the receipt. Never treat trust data bundled by an untrusted sender as authoritative.
+3. Build the public-only input described in [references/input-format.md](references/input-format.md). Omit `policy.now` for a live check so the verifier uses current Unix time.
+4. Install the pinned dependencies once with `npm ci --ignore-scripts` if they are not already present.
+5. Run `node scripts/verify-receipt.mjs --input <file.json>`.
+6. Report signature validity and authorization separately. Also report freshness, resource binding, and transaction-reference status.
+7. Treat exit `0` as all configured checks passing, exit `2` as a completed verification with one or more failed checks, and exit `1` as unreadable or malformed input.
+
+## Required Safety Boundaries
+
+- Accept only public verification material. Never request a private key, seed phrase, wallet connection, API credential, or symmetric JWK.
+- Require explicit authorized signers for EIP-712. For JWS, select one exact trusted key entry by DID URL `kid`, then enforce that entry's public JWK and allowed algorithms.
+- Use exact expected `resourceUrl`, `network`, and `payer` bindings. Do not infer them from the signed receipt.
+- Enforce both maximum age and future-clock-skew limits.
+- Do not fetch remote DID documents or keys automatically.
+- Do not claim a transaction was settled. A transaction value is checked only for presence or exact string equality.
+- Do not claim the response body was correct, complete, valuable, or delivered. A valid receipt is only the server's signed statement.
+
+## Development Checks
+
+Run `npm run verify:jws` for a copy-paste smoke test. Run `npm run fixtures` to regenerate deterministic tracked JWS fixtures and create the EIP-712 fixture only in a printed system temporary path. Run `npm test` for all negative and positive verification cases. Fixture signing material is public test material derived inside the generator and must never be used for funds or production trust.

--- a/skills/x402-offer-receipt-verifier/fixtures/jws-missing-kid.json
+++ b/skills/x402-offer-receipt-verifier/fixtures/jws-missing-kid.json
@@ -1,0 +1,37 @@
+{
+  "receipt": {
+    "format": "jws",
+    "signature": "eyJhbGciOiJFZERTQSJ9.eyJpc3N1ZWRBdCI6MTg5MzQ1NjAwMCwibmV0d29yayI6ImVpcDE1NTo4NDUzIiwicGF5ZXIiOiJkaWQ6a2V5OmZpeHR1cmUtcGF5ZXIiLCJyZXNvdXJjZVVybCI6Imh0dHBzOi8vcmVjZWlwdHMuZXhhbXBsZS50ZXN0L3ByZW1pdW0tZGF0YSIsInRyYW5zYWN0aW9uIjoiZml4dHVyZS10cmFuc2FjdGlvbi0wMDEiLCJ2ZXJzaW9uIjoxfQ.sZiJKfd59qGGKorjwQ8ZYbvCD8U5NjSuar4e5Dn9TK7sJL3xWW1V-EFQ4cj5TEnVghDklmXgAMkWp6KzxMJ8DQ"
+  },
+  "trust": {
+    "jwsKeys": [
+      {
+        "kid": "did:web:receipts.example.test#fixture-ed25519",
+        "publicJwk": {
+          "crv": "Ed25519",
+          "x": "c3328GitwhcP7basOH3jO0T8YXpw5zJwXlqik-WMxy0",
+          "kty": "OKP",
+          "alg": "EdDSA",
+          "use": "sig",
+          "kid": "did:web:receipts.example.test#fixture-ed25519",
+          "key_ops": [
+            "verify"
+          ]
+        },
+        "allowedAlgorithms": [
+          "EdDSA"
+        ]
+      }
+    ]
+  },
+  "policy": {
+    "now": 1893456030,
+    "maxAgeSeconds": 300,
+    "maxFutureSkewSeconds": 30,
+    "expectedResourceUrl": "https://receipts.example.test/premium-data",
+    "expectedNetwork": "eip155:8453",
+    "expectedPayer": "did:key:fixture-payer",
+    "requireTransaction": true,
+    "expectedTransaction": "fixture-transaction-001"
+  }
+}

--- a/skills/x402-offer-receipt-verifier/fixtures/jws-valid.json
+++ b/skills/x402-offer-receipt-verifier/fixtures/jws-valid.json
@@ -1,0 +1,37 @@
+{
+  "receipt": {
+    "format": "jws",
+    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6cmVjZWlwdHMuZXhhbXBsZS50ZXN0I2ZpeHR1cmUtZWQyNTUxOSJ9.eyJpc3N1ZWRBdCI6MTg5MzQ1NjAwMCwibmV0d29yayI6ImVpcDE1NTo4NDUzIiwicGF5ZXIiOiJkaWQ6a2V5OmZpeHR1cmUtcGF5ZXIiLCJyZXNvdXJjZVVybCI6Imh0dHBzOi8vcmVjZWlwdHMuZXhhbXBsZS50ZXN0L3ByZW1pdW0tZGF0YSIsInRyYW5zYWN0aW9uIjoiZml4dHVyZS10cmFuc2FjdGlvbi0wMDEiLCJ2ZXJzaW9uIjoxfQ.790UJsPFKiyAf1Zg4eWm2dLGux0kaS2QiwKRDKs6b_3D1kmhB0D4zQjLpwMiuL_BgH98BNl6VU0DFaHOrbcQDQ"
+  },
+  "trust": {
+    "jwsKeys": [
+      {
+        "kid": "did:web:receipts.example.test#fixture-ed25519",
+        "publicJwk": {
+          "crv": "Ed25519",
+          "x": "c3328GitwhcP7basOH3jO0T8YXpw5zJwXlqik-WMxy0",
+          "kty": "OKP",
+          "alg": "EdDSA",
+          "use": "sig",
+          "kid": "did:web:receipts.example.test#fixture-ed25519",
+          "key_ops": [
+            "verify"
+          ]
+        },
+        "allowedAlgorithms": [
+          "EdDSA"
+        ]
+      }
+    ]
+  },
+  "policy": {
+    "now": 1893456030,
+    "maxAgeSeconds": 300,
+    "maxFutureSkewSeconds": 30,
+    "expectedResourceUrl": "https://receipts.example.test/premium-data",
+    "expectedNetwork": "eip155:8453",
+    "expectedPayer": "did:key:fixture-payer",
+    "requireTransaction": true,
+    "expectedTransaction": "fixture-transaction-001"
+  }
+}

--- a/skills/x402-offer-receipt-verifier/package-lock.json
+++ b/skills/x402-offer-receipt-verifier/package-lock.json
@@ -1,0 +1,396 @@
+{
+  "name": "x402-offer-receipt-verifier",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "x402-offer-receipt-verifier",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@x402/extensions": "2.23.0"
+      },
+      "devDependencies": {
+        "viem": "2.55.19"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@signinwithethereum/siwe": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@signinwithethereum/siwe/-/siwe-4.2.0.tgz",
+      "integrity": "sha512-6W+oyKgMFUZRJI4o9P9mTMzrokkXfu3tq1/CfOJj9QrMqyPqujJqv1xnxUAqDQwWVyCA8TMg0Fxk/+gXrDg2Nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@signinwithethereum/siwe-parser": "^4.2.0"
+      },
+      "peerDependencies": {
+        "ethers": "^5.7.0 || ^6.13.0",
+        "viem": "^2.7.0"
+      },
+      "peerDependenciesMeta": {
+        "ethers": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@signinwithethereum/siwe-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@signinwithethereum/siwe-parser/-/siwe-parser-4.2.0.tgz",
+      "integrity": "sha512-e3edh8XpZrEjbzVYc0BZ4ySFOa8RKTZOQTafSf1E6ejCB5XcBH93jEpYmjzry1EEocgMNq4KlB3YunsFNCXakQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.7.0",
+        "apg-js": "^4.4.0"
+      }
+    },
+    "node_modules/@x402/core": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.23.0.tgz",
+      "integrity": "sha512-EFeV0nXbTPPe5FXaD6y9vMgqc+k/ujLXCrUPrQXkmHjHyjC3Ir5tTL1e2FPSkx2+GUGzfpt1wVZb36639ygkWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/extensions": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@x402/extensions/-/extensions-2.23.0.tgz",
+      "integrity": "sha512-K0hDWGNrQ5iU8CdDzM8RpYrMusfqs2rgZJbCfUnFXG61TjgFIYYyLExaP8jJ4y2ac0SGXYZC1MI+uJA6YP3TTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.0",
+        "@scure/base": "^1.2.6",
+        "@signinwithethereum/siwe": "^4.1.0",
+        "@x402/core": "~2.23.0",
+        "ajv": "^8.17.1",
+        "jose": "^5.9.6",
+        "tweetnacl": "^1.0.3",
+        "viem": "^2.48.11",
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/apg-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.4.0.tgz",
+      "integrity": "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/ox": {
+      "version": "0.14.34",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.34.tgz",
+      "integrity": "sha512-12seOIk7dv8eAoGQhcWaeKZxNz304IVcDvb9U5Y7JZAEVe21Nm1YMxLjhWah+su5BD4Omx4Zz0z5x3ij9M4GYQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/viem": {
+      "version": "2.55.19",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.19.tgz",
+      "integrity": "sha512-4QPIX0eYPLsOBk53NKswVMkQoxuP7GlOBnB4wM6dkDokREO4QENNc3bmyPKK1PBTViXh0TPJCHLjIuU20Qi3fg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.34",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/skills/x402-offer-receipt-verifier/package.json
+++ b/skills/x402-offer-receipt-verifier/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "x402-offer-receipt-verifier",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "fixtures": "node scripts/generate-fixtures.mjs",
+    "test": "node --test tests/*.test.mjs",
+    "verify:jws": "node scripts/verify-receipt.mjs --input fixtures/jws-valid.json"
+  },
+  "dependencies": {
+    "@x402/extensions": "2.23.0"
+  },
+  "devDependencies": {
+    "viem": "2.55.19"
+  }
+}

--- a/skills/x402-offer-receipt-verifier/references/input-format.md
+++ b/skills/x402-offer-receipt-verifier/references/input-format.md
@@ -1,0 +1,84 @@
+# Verifier Input Format
+
+The input is one JSON object containing a receipt plus caller-controlled trust and binding policy. All fields are public. Trust and policy must be assembled from an independent trusted source, not copied from an untrusted receipt bundle.
+
+## EIP-712
+
+```json
+{
+  "receipt": {
+    "format": "eip712",
+    "payload": {
+      "version": 1,
+      "network": "eip155:<chain-id>",
+      "resourceUrl": "https://service.example/resource",
+      "payer": "<expected-payer-identifier>",
+      "issuedAt": 1893456000,
+      "transaction": "<signed-transaction-reference>"
+    },
+    "signature": "<eip712-signature>"
+  },
+  "trust": {
+    "authorizedSigners": ["<authorized-eip712-signer>"]
+  },
+  "policy": {
+    "maxAgeSeconds": 300,
+    "maxFutureSkewSeconds": 30,
+    "expectedResourceUrl": "https://service.example/resource",
+    "expectedNetwork": "eip155:<chain-id>",
+    "expectedPayer": "<expected-payer-identifier>",
+    "requireTransaction": true,
+    "expectedTransaction": "<expected-transaction-reference>"
+  }
+}
+```
+
+EIP-712 signer comparison is case-insensitive. The official version 1 typed-data schema includes `transaction`; an empty value can still fail `requireTransaction` policy.
+
+## JWS
+
+```json
+{
+  "receipt": {
+    "format": "jws",
+    "signature": "<compact-jws>"
+  },
+  "trust": {
+    "jwsKeys": [
+      {
+        "kid": "did:web:service.example#receipt-key",
+        "publicJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "<public-key-material>",
+          "kid": "did:web:service.example#receipt-key",
+          "alg": "EdDSA",
+          "use": "sig",
+          "key_ops": ["verify"]
+        },
+        "allowedAlgorithms": ["EdDSA"]
+      }
+    ]
+  },
+  "policy": {
+    "maxAgeSeconds": 300,
+    "maxFutureSkewSeconds": 30,
+    "expectedResourceUrl": "https://service.example/resource",
+    "expectedNetwork": "eip155:<chain-id>",
+    "expectedPayer": "<expected-payer-identifier>"
+  }
+}
+```
+
+The JWS protected header must contain a DID URL `kid`. The verifier selects exactly one `trust.jwsKeys` entry by that value, then uses only the public JWK and algorithms bound to that entry. When the JWK contains `kid`, `alg`, `use`, or `key_ops`, they must match the protected header and verification purpose. The verifier rejects private or symmetric key members and never resolves the DID URL remotely.
+
+## Policy Details
+
+- `expectedResourceUrl`, `expectedNetwork`, and `expectedPayer` are required and compared exactly.
+- `maxAgeSeconds` defaults to `3600`.
+- `maxFutureSkewSeconds` defaults to `60`.
+- `now` is optional Unix time in seconds. Omit it for live verification; deterministic fixtures pin it.
+- `requireTransaction` requires a non-empty signed reference.
+- `expectedTransaction` performs exact string comparison only. It does not query a chain.
+
+The output is JSON. Error objects have stable `code` and human-readable `message` fields. Treat the structured code as the automation contract.

--- a/skills/x402-offer-receipt-verifier/scripts/generate-fixtures.mjs
+++ b/skills/x402-offer-receipt-verifier/scripts/generate-fixtures.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  sign as signBytes,
+} from "node:crypto";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  createJWS,
+  signReceiptEIP712,
+} from "@x402/extensions/offer-receipt";
+import { privateKeyToAccount } from "viem/accounts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtureDirectory = join(here, "..", "fixtures");
+
+const payload = {
+  version: 1,
+  network: "eip155:8453",
+  resourceUrl: "https://receipts.example.test/premium-data",
+  payer: "did:key:fixture-payer",
+  issuedAt: 1893456000,
+  transaction: "fixture-transaction-001",
+};
+
+function deterministicBytes(label) {
+  return createHash("sha256").update(label, "utf8").digest();
+}
+
+function json(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function policyFor(receiptPayload) {
+  return {
+    now: 1893456030,
+    maxAgeSeconds: 300,
+    maxFutureSkewSeconds: 30,
+    expectedResourceUrl: receiptPayload.resourceUrl,
+    expectedNetwork: receiptPayload.network,
+    expectedPayer: receiptPayload.payer,
+    requireTransaction: true,
+    expectedTransaction: receiptPayload.transaction,
+  };
+}
+
+export async function buildEIP712Fixture(payloadOverrides = {}) {
+  const receiptPayload = { ...payload, ...payloadOverrides };
+  const privateKey = `0x${deterministicBytes(
+    "x402-offer-receipt-verifier/eip712-fixture-only",
+  ).toString("hex")}`;
+  const account = privateKeyToAccount(privateKey);
+  const signature = await signReceiptEIP712(receiptPayload, parameters =>
+    account.signTypedData(parameters),
+  );
+
+  return {
+    receipt: {
+      format: "eip712",
+      payload: receiptPayload,
+      signature,
+    },
+    trust: {
+      authorizedSigners: [account.address],
+    },
+    policy: policyFor(receiptPayload),
+  };
+}
+
+function buildEd25519KeyPair() {
+  const seed = deterministicBytes(
+    "x402-offer-receipt-verifier/jws-fixture-only",
+  );
+  const pkcs8Prefix = Buffer.from("302e020100300506032b657004220420", "hex");
+  const privateKey = createPrivateKey({
+    key: Buffer.concat([pkcs8Prefix, seed]),
+    format: "der",
+    type: "pkcs8",
+  });
+  const publicJwk = createPublicKey(privateKey).export({ format: "jwk" });
+
+  return {
+    privateKey,
+    publicJwk: {
+      ...publicJwk,
+      alg: "EdDSA",
+      use: "sig",
+    },
+  };
+}
+
+export async function buildJWSFixture({ includeKid }) {
+  const { privateKey, publicJwk } = buildEd25519KeyPair();
+  const kid = "did:web:receipts.example.test#fixture-ed25519";
+  const signature = await createJWS(payload, {
+    format: "jws",
+    algorithm: "EdDSA",
+    kid: includeKid ? kid : undefined,
+    async sign(input) {
+      return signBytes(null, input, privateKey).toString("base64url");
+    },
+  });
+
+  return {
+    receipt: {
+      format: "jws",
+      signature,
+    },
+    trust: {
+      jwsKeys: [
+        {
+          kid,
+          publicJwk: {
+            ...publicJwk,
+            kid,
+            key_ops: ["verify"],
+          },
+          allowedAlgorithms: ["EdDSA"],
+        },
+      ],
+    },
+    policy: policyFor(payload),
+  };
+}
+
+async function main() {
+  await mkdir(fixtureDirectory, { recursive: true });
+  await Promise.all([
+    writeFile(
+      join(fixtureDirectory, "jws-valid.json"),
+      json(await buildJWSFixture({ includeKid: true })),
+    ),
+    writeFile(
+      join(fixtureDirectory, "jws-missing-kid.json"),
+      json(await buildJWSFixture({ includeKid: false })),
+    ),
+  ]);
+
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "x402-offer-receipt-verifier-eip712-"),
+  );
+  const temporaryEip712Path = join(temporaryDirectory, "eip712-valid.json");
+  await writeFile(temporaryEip712Path, json(await buildEIP712Fixture()));
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        trackedJwsFixtures: fixtureDirectory,
+        temporaryEip712Fixture: temporaryEip712Path,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/skills/x402-offer-receipt-verifier/scripts/verify-receipt.mjs
+++ b/skills/x402-offer-receipt-verifier/scripts/verify-receipt.mjs
@@ -1,0 +1,657 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+import {
+  extractJWSHeader,
+  verifyReceiptSignatureEIP712,
+  verifyReceiptSignatureJWS,
+} from "@x402/extensions/offer-receipt";
+
+const PAYLOAD_FIELDS = new Set([
+  "version",
+  "network",
+  "resourceUrl",
+  "payer",
+  "issuedAt",
+  "transaction",
+]);
+const CAIP2_PATTERN = /^[-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32}$/;
+const EIP155_PATTERN = /^eip155:[0-9]+$/;
+const DID_URL_PATTERN =
+  /^did:[a-z0-9]+:[^/?#\s]+(?:\/[^?#\s]*)?(?:\?[^#\s]*)?(?:#[^\s]*)?$/;
+const PRIVATE_JWK_FIELDS = ["d", "p", "q", "dp", "dq", "qi", "oth", "k"];
+const RECEIPT_FIELDS = {
+  eip712: new Set(["format", "payload", "signature"]),
+  jws: new Set(["format", "signature"]),
+};
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function addError(errors, code, message) {
+  if (!errors.some(error => error.code === code)) {
+    errors.push({ code, message });
+  }
+}
+
+function validateNonNegativeInteger(value, field, errors) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    addError(errors, "INVALID_POLICY", `${field} must be a non-negative integer`);
+    return false;
+  }
+  return true;
+}
+
+function validatePayload(payload, format) {
+  const errors = [];
+  if (!isObject(payload)) {
+    addError(errors, "MALFORMED_PAYLOAD", "Receipt payload must be an object");
+    return errors;
+  }
+
+  const required = ["version", "network", "resourceUrl", "payer", "issuedAt"];
+  if (format === "eip712") {
+    required.push("transaction");
+  }
+  for (const field of required) {
+    if (!Object.hasOwn(payload, field)) {
+      addError(errors, "MISSING_FIELD", `Receipt payload is missing ${field}`);
+    }
+  }
+  for (const field of Object.keys(payload)) {
+    if (!PAYLOAD_FIELDS.has(field)) {
+      addError(errors, "UNEXPECTED_FIELD", `Receipt payload has unexpected field ${field}`);
+    }
+  }
+
+  if (Object.hasOwn(payload, "version") && payload.version !== 1) {
+    addError(errors, "UNSUPPORTED_VERSION", "Only receipt payload version 1 is supported");
+  }
+  if (
+    Object.hasOwn(payload, "network") &&
+    (typeof payload.network !== "string" ||
+      (format === "eip712"
+        ? !EIP155_PATTERN.test(payload.network)
+        : !CAIP2_PATTERN.test(payload.network)))
+  ) {
+    addError(
+      errors,
+      "INVALID_NETWORK",
+      format === "eip712"
+        ? "EIP-712 network must use eip155:<chainId>"
+        : "network must be a CAIP-2 identifier",
+    );
+  }
+  if (Object.hasOwn(payload, "resourceUrl")) {
+    try {
+      const resourceUrl = new URL(payload.resourceUrl);
+      if (resourceUrl.protocol !== "https:") {
+        throw new Error("HTTPS required");
+      }
+    } catch {
+      addError(errors, "INVALID_FIELD", "resourceUrl must be an absolute HTTPS URL");
+    }
+  }
+  if (
+    Object.hasOwn(payload, "payer") &&
+    (typeof payload.payer !== "string" || payload.payer.length === 0)
+  ) {
+    addError(errors, "INVALID_FIELD", "payer must be a non-empty string");
+  }
+  if (
+    Object.hasOwn(payload, "issuedAt") &&
+    (!Number.isSafeInteger(payload.issuedAt) || payload.issuedAt < 0)
+  ) {
+    addError(errors, "INVALID_FIELD", "issuedAt must be a non-negative integer");
+  }
+  if (
+    Object.hasOwn(payload, "transaction") &&
+    typeof payload.transaction !== "string"
+  ) {
+    addError(errors, "INVALID_FIELD", "transaction must be a string when present");
+  }
+
+  return errors;
+}
+
+function validateReceiptEnvelope(receipt, format) {
+  const errors = [];
+  if (!isObject(receipt) || !RECEIPT_FIELDS[format]) {
+    return errors;
+  }
+
+  const allowedFields = RECEIPT_FIELDS[format];
+  for (const field of Object.keys(receipt)) {
+    if (!allowedFields.has(field)) {
+      addError(
+        errors,
+        "UNEXPECTED_RECEIPT_FIELD",
+        `${format} receipt has unexpected field ${field}`,
+      );
+    }
+  }
+
+  for (const field of allowedFields) {
+    if (!Object.hasOwn(receipt, field)) {
+      addError(
+        errors,
+        "MISSING_RECEIPT_FIELD",
+        `${format} receipt is missing ${field}`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+function validatePolicy(policy, errors) {
+  if (!isObject(policy)) {
+    addError(errors, "INVALID_POLICY", "policy must be an object");
+    return null;
+  }
+
+  const now = policy.now ?? Math.floor(Date.now() / 1000);
+  const maxAgeSeconds = policy.maxAgeSeconds ?? 3600;
+  const maxFutureSkewSeconds = policy.maxFutureSkewSeconds ?? 60;
+  validateNonNegativeInteger(now, "policy.now", errors);
+  validateNonNegativeInteger(
+    maxAgeSeconds,
+    "policy.maxAgeSeconds",
+    errors,
+  );
+  validateNonNegativeInteger(
+    maxFutureSkewSeconds,
+    "policy.maxFutureSkewSeconds",
+    errors,
+  );
+
+  for (const field of [
+    "expectedResourceUrl",
+    "expectedNetwork",
+    "expectedPayer",
+  ]) {
+    if (typeof policy[field] !== "string" || policy[field].length === 0) {
+      addError(
+        errors,
+        "MISSING_EXPECTED_BINDING",
+        `policy.${field} is required`,
+      );
+    }
+  }
+  if (
+    Object.hasOwn(policy, "expectedTransaction") &&
+    typeof policy.expectedTransaction !== "string"
+  ) {
+    addError(
+      errors,
+      "INVALID_POLICY",
+      "policy.expectedTransaction must be a string",
+    );
+  }
+  if (
+    Object.hasOwn(policy, "requireTransaction") &&
+    typeof policy.requireTransaction !== "boolean"
+  ) {
+    addError(
+      errors,
+      "INVALID_POLICY",
+      "policy.requireTransaction must be a boolean",
+    );
+  }
+
+  return { now, maxAgeSeconds, maxFutureSkewSeconds };
+}
+
+function checkFreshness(payload, policy, timing, errors) {
+  if (!timing || !Number.isSafeInteger(payload?.issuedAt)) {
+    return {
+      valid: false,
+      evaluatedAt: timing?.now ?? null,
+      ageSeconds: null,
+      maxAgeSeconds: timing?.maxAgeSeconds ?? null,
+      maxFutureSkewSeconds: timing?.maxFutureSkewSeconds ?? null,
+    };
+  }
+
+  const ageSeconds = timing.now - payload.issuedAt;
+  if (ageSeconds > timing.maxAgeSeconds) {
+    addError(errors, "STALE_RECEIPT", "Receipt is older than policy allows");
+  }
+  if (ageSeconds < -timing.maxFutureSkewSeconds) {
+    addError(errors, "FUTURE_RECEIPT", "Receipt timestamp is too far in the future");
+  }
+
+  return {
+    valid:
+      ageSeconds <= timing.maxAgeSeconds &&
+      ageSeconds >= -timing.maxFutureSkewSeconds,
+    evaluatedAt: timing.now,
+    ageSeconds,
+    maxAgeSeconds: timing.maxAgeSeconds,
+    maxFutureSkewSeconds: timing.maxFutureSkewSeconds,
+  };
+}
+
+function checkBinding(payload, policy, errors) {
+  const mismatches = [];
+  const bindings = [
+    ["resourceUrl", "expectedResourceUrl", "RESOURCE_URL_MISMATCH"],
+    ["network", "expectedNetwork", "NETWORK_MISMATCH"],
+    ["payer", "expectedPayer", "PAYER_MISMATCH"],
+  ];
+
+  for (const [payloadField, policyField, code] of bindings) {
+    if (payload?.[payloadField] !== policy?.[policyField]) {
+      mismatches.push(payloadField);
+      addError(errors, code, `Receipt ${payloadField} does not match policy`);
+    }
+  }
+
+  return { valid: mismatches.length === 0, mismatches };
+}
+
+function checkTransaction(payload, policy, errors) {
+  const transaction = payload?.transaction;
+  const present = typeof transaction === "string" && transaction.length > 0;
+
+  if (policy?.requireTransaction === true && !present) {
+    addError(
+      errors,
+      "TRANSACTION_REQUIRED",
+      "Policy requires a transaction reference",
+    );
+  }
+  if (
+    Object.hasOwn(policy ?? {}, "expectedTransaction") &&
+    transaction !== policy.expectedTransaction
+  ) {
+    addError(
+      errors,
+      "TRANSACTION_MISMATCH",
+      "Receipt transaction does not match policy",
+    );
+  }
+
+  const valid =
+    !(policy?.requireTransaction === true && !present) &&
+    !(
+      Object.hasOwn(policy ?? {}, "expectedTransaction") &&
+      transaction !== policy.expectedTransaction
+    );
+  let status = "not-required";
+  if (Object.hasOwn(policy ?? {}, "expectedTransaction")) {
+    status = valid ? "matched" : "mismatch";
+  } else if (present) {
+    status = "present-not-checked";
+  } else if (policy?.requireTransaction === true) {
+    status = "missing";
+  }
+
+  return {
+    valid,
+    status,
+    present,
+    note:
+      status === "present-not-checked"
+        ? "Reference is signed but no chain lookup was performed"
+        : undefined,
+  };
+}
+
+async function verifyEIP712(receipt, trust, errors) {
+  const signature = { valid: false, signer: null };
+  const authorization = {
+    valid: false,
+    method: "authorized-signers",
+    subject: null,
+  };
+
+  if (!Array.isArray(trust?.authorizedSigners) || trust.authorizedSigners.length === 0) {
+    addError(
+      errors,
+      "MISSING_AUTHORIZATION",
+      "trust.authorizedSigners must contain at least one signer",
+    );
+    return { signature, authorization, payload: receipt?.payload ?? null };
+  }
+  if (
+    trust.authorizedSigners.some(
+      signer => typeof signer !== "string" || signer.length === 0,
+    )
+  ) {
+    addError(
+      errors,
+      "INVALID_AUTHORIZATION",
+      "Every authorized signer must be a non-empty string",
+    );
+    return { signature, authorization, payload: receipt?.payload ?? null };
+  }
+
+  try {
+    const verified = await verifyReceiptSignatureEIP712(receipt);
+    const signer = verified.signer.toLowerCase();
+    signature.valid = true;
+    signature.signer = signer;
+    authorization.subject = signer;
+    authorization.valid = trust.authorizedSigners.some(
+      allowed => allowed.toLowerCase() === signer,
+    );
+    if (!authorization.valid) {
+      addError(
+        errors,
+        "UNAUTHORIZED_SIGNER",
+        "Recovered signer is not authorized by policy",
+      );
+    }
+    return { signature, authorization, payload: verified.payload };
+  } catch {
+    addError(errors, "SIGNATURE_INVALID", "EIP-712 signature verification failed");
+    return { signature, authorization, payload: receipt?.payload ?? null };
+  }
+}
+
+async function verifyJWS(receipt, trust, errors) {
+  const signature = { valid: false, algorithm: null, kid: null };
+  const authorization = {
+    valid: false,
+    method: "trusted-jws-key",
+    subject: null,
+  };
+
+  let header;
+  try {
+    header = extractJWSHeader(receipt.signature);
+    signature.algorithm = header.alg ?? null;
+    signature.kid = header.kid ?? null;
+  } catch {
+    addError(errors, "MALFORMED_JWS", "JWS compact serialization is malformed");
+    return { signature, authorization, payload: null };
+  }
+
+  if (typeof header.kid !== "string" || header.kid.length === 0) {
+    addError(errors, "MISSING_KID", "JWS protected header must contain kid");
+    return { signature, authorization, payload: null };
+  }
+  if (!DID_URL_PATTERN.test(header.kid)) {
+    addError(errors, "INVALID_KID", "JWS kid must be a DID URL");
+    return { signature, authorization, payload: null };
+  }
+  if (!Array.isArray(trust?.jwsKeys) || trust.jwsKeys.length === 0) {
+    addError(
+      errors,
+      "MISSING_AUTHORIZATION",
+      "trust.jwsKeys must contain at least one trusted key policy",
+    );
+    return { signature, authorization, payload: null };
+  }
+
+  const matchingKeys = trust.jwsKeys.filter(
+    entry => isObject(entry) && entry.kid === header.kid,
+  );
+  if (matchingKeys.length === 0) {
+    addError(errors, "UNAUTHORIZED_KID", "JWS kid is not authorized by policy");
+    return { signature, authorization, payload: null };
+  }
+  if (matchingKeys.length > 1) {
+    addError(
+      errors,
+      "DUPLICATE_KID_POLICY",
+      "JWS kid matches more than one trusted key policy",
+    );
+    return { signature, authorization, payload: null };
+  }
+
+  const trustedKey = matchingKeys[0];
+  authorization.subject = header.kid;
+
+  if (
+    !Array.isArray(trustedKey.allowedAlgorithms) ||
+    trustedKey.allowedAlgorithms.length === 0 ||
+    trustedKey.allowedAlgorithms.some(algorithm => typeof algorithm !== "string")
+  ) {
+    addError(
+      errors,
+      "MISSING_ALGORITHM_POLICY",
+      "Each trusted JWS key must declare allowedAlgorithms",
+    );
+    return { signature, authorization, payload: null };
+  }
+  if (!trustedKey.allowedAlgorithms.includes(header.alg)) {
+    addError(
+      errors,
+      "ALGORITHM_NOT_ALLOWED",
+      "JWS algorithm is not allowed by policy",
+    );
+    return { signature, authorization, payload: null };
+  }
+  if (!isObject(trustedKey.publicJwk)) {
+    addError(
+      errors,
+      "MISSING_PUBLIC_JWK",
+      "Each trusted JWS key must include publicJwk",
+    );
+    return { signature, authorization, payload: null };
+  }
+  if (
+    PRIVATE_JWK_FIELDS.some(field =>
+      Object.hasOwn(trustedKey.publicJwk, field),
+    )
+  ) {
+    addError(
+      errors,
+      "PRIVATE_JWK_FORBIDDEN",
+      "Only asymmetric public JWK material is accepted",
+    );
+    return { signature, authorization, payload: null };
+  }
+  if (
+    Object.hasOwn(trustedKey.publicJwk, "kid") &&
+    trustedKey.publicJwk.kid !== header.kid
+  ) {
+    addError(
+      errors,
+      "JWK_KID_MISMATCH",
+      "Public JWK kid does not match the protected-header kid",
+    );
+    return { signature, authorization, payload: null };
+  }
+  if (
+    Object.hasOwn(trustedKey.publicJwk, "alg") &&
+    trustedKey.publicJwk.alg !== header.alg
+  ) {
+    addError(
+      errors,
+      "JWK_ALGORITHM_MISMATCH",
+      "Public JWK algorithm does not match the protected-header algorithm",
+    );
+    return { signature, authorization, payload: null };
+  }
+  if (
+    Object.hasOwn(trustedKey.publicJwk, "use") &&
+    trustedKey.publicJwk.use !== "sig"
+  ) {
+    addError(
+      errors,
+      "JWK_USE_INVALID",
+      "Public JWK use must be sig when present",
+    );
+    return { signature, authorization, payload: null };
+  }
+  if (
+    Object.hasOwn(trustedKey.publicJwk, "key_ops") &&
+    (!Array.isArray(trustedKey.publicJwk.key_ops) ||
+      !trustedKey.publicJwk.key_ops.includes("verify"))
+  ) {
+    addError(
+      errors,
+      "JWK_KEY_OPS_INVALID",
+      "Public JWK key_ops must include verify when present",
+    );
+    return { signature, authorization, payload: null };
+  }
+
+  let payload;
+  try {
+    payload = await verifyReceiptSignatureJWS(receipt, trustedKey.publicJwk);
+    signature.valid = true;
+    authorization.valid = true;
+  } catch {
+    addError(errors, "SIGNATURE_INVALID", "JWS signature verification failed");
+    return { signature, authorization, payload: null };
+  }
+
+  return { signature, authorization, payload };
+}
+
+export async function verifyReceiptInput(input) {
+  const errors = [];
+  const receipt = input?.receipt;
+  const trust = input?.trust;
+  const policy = input?.policy;
+  const format = receipt?.format ?? null;
+  const checks = {
+    schema: { valid: false },
+    signature: { valid: false },
+    authorization: { valid: false },
+    freshness: { valid: false },
+    binding: { valid: false, mismatches: [] },
+    transaction: { valid: false, status: "not-checked", present: false },
+  };
+
+  if (!isObject(input)) {
+    addError(errors, "INVALID_INPUT", "Input must be a JSON object");
+  }
+  if (!isObject(receipt)) {
+    addError(errors, "MISSING_RECEIPT", "receipt must be an object");
+  }
+  if (format !== "eip712" && format !== "jws") {
+    addError(errors, "UNSUPPORTED_FORMAT", "Receipt format must be eip712 or jws");
+  }
+  if (typeof receipt?.signature !== "string" || receipt.signature.length === 0) {
+    addError(errors, "MISSING_SIGNATURE", "Receipt signature is required");
+  }
+
+  const envelopeErrors = validateReceiptEnvelope(receipt, format);
+  envelopeErrors.forEach(error => addError(errors, error.code, error.message));
+
+  const timing = validatePolicy(policy, errors);
+  let payload = null;
+
+  if (
+    isObject(receipt) &&
+    typeof receipt.signature === "string" &&
+    receipt.signature.length > 0 &&
+    format === "eip712" &&
+    envelopeErrors.length === 0
+  ) {
+    const payloadErrors = validatePayload(receipt.payload, format);
+    payloadErrors.forEach(error => addError(errors, error.code, error.message));
+    checks.schema.valid = payloadErrors.length === 0;
+    if (checks.schema.valid) {
+      const verified = await verifyEIP712(receipt, trust, errors);
+      checks.signature = verified.signature;
+      checks.authorization = verified.authorization;
+      payload = verified.payload;
+    } else {
+      payload = receipt.payload ?? null;
+    }
+  } else if (
+    isObject(receipt) &&
+    typeof receipt.signature === "string" &&
+    receipt.signature.length > 0 &&
+    format === "jws" &&
+    envelopeErrors.length === 0
+  ) {
+    const verified = await verifyJWS(receipt, trust, errors);
+    checks.signature = verified.signature;
+    checks.authorization = verified.authorization;
+    payload = verified.payload;
+    if (payload !== null) {
+      const payloadErrors = validatePayload(payload, format);
+      payloadErrors.forEach(error => addError(errors, error.code, error.message));
+      checks.schema.valid = payloadErrors.length === 0;
+    }
+  } else if (format === "eip712") {
+    payload = receipt?.payload ?? null;
+  }
+
+  if (checks.schema.valid && payload !== null) {
+    checks.freshness = checkFreshness(payload, policy, timing, errors);
+    checks.binding = checkBinding(payload, policy, errors);
+    checks.transaction = checkTransaction(payload, policy, errors);
+  }
+
+  const valid =
+    errors.length === 0 &&
+    Object.values(checks).every(check => check.valid === true);
+
+  return {
+    valid,
+    format,
+    payload,
+    checks,
+    errors,
+    limitations: [
+      "No remote DID resolution is performed",
+      "No blockchain transaction lookup is performed",
+      "A valid receipt is the server's signed statement and does not prove response quality",
+    ],
+  };
+}
+
+function parseInputPath(arguments_) {
+  if (arguments_.length === 1 && arguments_[0] === "--help") {
+    return { help: true, inputPath: null };
+  }
+  const inputIndex = arguments_.indexOf("--input");
+  if (inputIndex === -1 || !arguments_[inputIndex + 1]) {
+    throw new Error("Usage: node scripts/verify-receipt.mjs --input <file.json>");
+  }
+  return { help: false, inputPath: arguments_[inputIndex + 1] };
+}
+
+async function main() {
+  try {
+    const { help, inputPath } = parseInputPath(process.argv.slice(2));
+    if (help) {
+      process.stdout.write(
+        "Usage: node scripts/verify-receipt.mjs --input <file.json>\n",
+      );
+      return;
+    }
+    const input = JSON.parse(await readFile(inputPath, "utf8"));
+    const result = await verifyReceiptInput(input);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    process.exitCode = result.valid ? 0 : 2;
+  } catch {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          valid: false,
+          format: null,
+          payload: null,
+          checks: {},
+          errors: [
+            {
+              code: "INPUT_ERROR",
+              message: "Unable to read or parse verifier input",
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/skills/x402-offer-receipt-verifier/tests/verify-receipt.test.mjs
+++ b/skills/x402-offer-receipt-verifier/tests/verify-receipt.test.mjs
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test, { before } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { buildEIP712Fixture } from "../scripts/generate-fixtures.mjs";
+
+const skillDirectory = join(dirname(fileURLToPath(import.meta.url)), "..");
+const cli = join(skillDirectory, "scripts", "verify-receipt.mjs");
+let eip712Fixture;
+
+before(async () => {
+  eip712Fixture = await buildEIP712Fixture();
+});
+
+function fixture(name) {
+  if (name === "eip712-valid.json") {
+    return structuredClone(eip712Fixture);
+  }
+  return JSON.parse(
+    readFileSync(join(skillDirectory, "fixtures", name), "utf8"),
+  );
+}
+
+function runVerifier(input) {
+  const temporaryDirectory = mkdtempSync(
+    join(tmpdir(), "x402-receipt-verifier-test-"),
+  );
+  const inputPath = join(temporaryDirectory, "input.json");
+  writeFileSync(inputPath, JSON.stringify(input));
+
+  try {
+    const result = spawnSync(process.execPath, [cli, "--input", inputPath], {
+      cwd: skillDirectory,
+      encoding: "utf8",
+    });
+    let output = null;
+    try {
+      output = JSON.parse(result.stdout);
+    } catch {
+      // Keep raw output available in the assertion diagnostic.
+    }
+    return {
+      status: result.status,
+      output,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function hasError(result, code) {
+  return result.output?.errors?.some(error => error.code === code) ?? false;
+}
+
+test("accepts a fresh authorized EIP-712 receipt", () => {
+  const result = runVerifier(fixture("eip712-valid.json"));
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(result.output.valid, true);
+  assert.equal(result.output.format, "eip712");
+  assert.equal(result.output.checks.signature.valid, true);
+  assert.equal(result.output.checks.authorization.valid, true);
+  assert.equal(result.output.checks.freshness.valid, true);
+  assert.equal(result.output.checks.binding.valid, true);
+  assert.equal(result.output.checks.transaction.valid, true);
+});
+
+test("accepts a fresh authorized JWS receipt with an explicit public JWK", () => {
+  const result = runVerifier(fixture("jws-valid.json"));
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(result.output.valid, true);
+  assert.equal(result.output.format, "jws");
+  assert.equal(result.output.checks.signature.valid, true);
+  assert.equal(result.output.checks.authorization.valid, true);
+});
+
+test("rejects an EIP-712 payload changed after signing", () => {
+  const input = fixture("eip712-valid.json");
+  input.receipt.payload.resourceUrl =
+    "https://receipts.example.test/tampered-data";
+
+  const result = runVerifier(input);
+
+  assert.equal(result.status, 2, result.stderr || result.stdout);
+  assert.equal(result.output.valid, false);
+  assert.equal(hasError(result, "UNAUTHORIZED_SIGNER"), true);
+});
+
+test("rejects a JWS payload changed after signing", () => {
+  const input = fixture("jws-valid.json");
+  const parts = input.receipt.signature.split(".");
+  const last = parts[1].at(-1);
+  parts[1] = `${parts[1].slice(0, -1)}${last === "A" ? "B" : "A"}`;
+  input.receipt.signature = parts.join(".");
+
+  const result = runVerifier(input);
+
+  assert.equal(result.status, 2, result.stderr || result.stdout);
+  assert.equal(result.output.valid, false);
+  assert.equal(result.output.checks.authorization.valid, false);
+  assert.equal(hasError(result, "SIGNATURE_INVALID"), true);
+});
+
+test("keeps signature validity separate from EIP-712 signer authorization", () => {
+  const input = fixture("eip712-valid.json");
+  const signer = input.trust.authorizedSigners[0];
+  const replacement = signer.at(-1).toLowerCase() === "a" ? "b" : "a";
+  input.trust.authorizedSigners = [`${signer.slice(0, -1)}${replacement}`];
+
+  const result = runVerifier(input);
+
+  assert.equal(result.status, 2, result.stderr || result.stdout);
+  assert.equal(result.output.checks.signature.valid, true);
+  assert.equal(result.output.checks.authorization.valid, false);
+  assert.equal(hasError(result, "UNAUTHORIZED_SIGNER"), true);
+});
+
+test("rejects a valid JWS whose kid is not authorized", () => {
+  const input = fixture("jws-valid.json");
+  input.trust.jwsKeys[0].kid = "did:web:receipts.example.test#different-key";
+
+  const result = runVerifier(input);
+
+  assert.equal(result.status, 2, result.stderr || result.stdout);
+  assert.equal(result.output.checks.signature.valid, false);
+  assert.equal(result.output.checks.authorization.valid, false);
+  assert.equal(hasError(result, "UNAUTHORIZED_KID"), true);
+});
+
+test("rejects stale and future receipts with distinct errors", () => {
+  const stale = fixture("jws-valid.json");
+  stale.policy.now = stale.policy.now + stale.policy.maxAgeSeconds + 1;
+  const staleResult = runVerifier(stale);
+
+  assert.equal(staleResult.status, 2, staleResult.stderr || staleResult.stdout);
+  assert.equal(hasError(staleResult, "STALE_RECEIPT"), true);
+
+  const future = fixture("eip712-valid.json");
+  future.policy.now =
+    future.receipt.payload.issuedAt - future.policy.maxFutureSkewSeconds - 1;
+  const futureResult = runVerifier(future);
+
+  assert.equal(futureResult.status, 2, futureResult.stderr || futureResult.stdout);
+  assert.equal(hasError(futureResult, "FUTURE_RECEIPT"), true);
+});
+
+test("rejects unsupported versions and missing EIP-712 transaction fields", () => {
+  const unsupported = fixture("eip712-valid.json");
+  unsupported.receipt.payload.version = 2;
+  const versionResult = runVerifier(unsupported);
+
+  assert.equal(versionResult.status, 2, versionResult.stderr || versionResult.stdout);
+  assert.equal(hasError(versionResult, "UNSUPPORTED_VERSION"), true);
+
+  const missingTransaction = fixture("eip712-valid.json");
+  delete missingTransaction.receipt.payload.transaction;
+  const transactionResult = runVerifier(missingTransaction);
+
+  assert.equal(
+    transactionResult.status,
+    2,
+    transactionResult.stderr || transactionResult.stdout,
+  );
+  assert.equal(hasError(transactionResult, "MISSING_FIELD"), true);
+
+  const wrongNetwork = fixture("eip712-valid.json");
+  wrongNetwork.receipt.payload.network = "solana:mainnet";
+  wrongNetwork.policy.expectedNetwork = "solana:mainnet";
+  const networkResult = runVerifier(wrongNetwork);
+
+  assert.equal(networkResult.status, 2, networkResult.stderr || networkResult.stdout);
+  assert.equal(hasError(networkResult, "INVALID_NETWORK"), true);
+});
+
+test("rejects missing or non-DID JWS kids and private JWK input", () => {
+  const noKidResult = runVerifier(fixture("jws-missing-kid.json"));
+
+  assert.equal(noKidResult.status, 2, noKidResult.stderr || noKidResult.stdout);
+  assert.equal(hasError(noKidResult, "MISSING_KID"), true);
+
+  const nonDidKid = fixture("jws-valid.json");
+  const parts = nonDidKid.receipt.signature.split(".");
+  const header = JSON.parse(Buffer.from(parts[0], "base64url").toString("utf8"));
+  header.kid = "https://receipts.example.test/fixture-ed25519";
+  parts[0] = Buffer.from(JSON.stringify(header)).toString("base64url");
+  nonDidKid.receipt.signature = parts.join(".");
+  const nonDidKidResult = runVerifier(nonDidKid);
+
+  assert.equal(
+    nonDidKidResult.status,
+    2,
+    nonDidKidResult.stderr || nonDidKidResult.stdout,
+  );
+  assert.equal(hasError(nonDidKidResult, "INVALID_KID"), true);
+
+  const privateJwk = fixture("jws-valid.json");
+  privateJwk.trust.jwsKeys[0].publicJwk.d =
+    "private-material-is-not-accepted";
+  const privateJwkResult = runVerifier(privateJwk);
+
+  assert.equal(
+    privateJwkResult.status,
+    2,
+    privateJwkResult.stderr || privateJwkResult.stdout,
+  );
+  assert.equal(hasError(privateJwkResult, "PRIVATE_JWK_FORBIDDEN"), true);
+
+  const symmetricJwk = fixture("jws-valid.json");
+  symmetricJwk.trust.jwsKeys[0].publicJwk = {
+    kty: "oct",
+    k: "symmetric-secret-is-not-accepted",
+  };
+  const symmetricJwkResult = runVerifier(symmetricJwk);
+
+  assert.equal(
+    symmetricJwkResult.status,
+    2,
+    symmetricJwkResult.stderr || symmetricJwkResult.stdout,
+  );
+  assert.equal(hasError(symmetricJwkResult, "PRIVATE_JWK_FORBIDDEN"), true);
+});
+
+test("binds each authorized JWS kid to exact public-key policy", () => {
+  const cases = [
+    {
+      code: "JWK_KID_MISMATCH",
+      mutate(input) {
+        input.trust.jwsKeys[0].publicJwk.kid =
+          "did:web:receipts.example.test#attacker-key";
+      },
+    },
+    {
+      code: "JWK_ALGORITHM_MISMATCH",
+      mutate(input) {
+        input.trust.jwsKeys[0].publicJwk.alg = "ES256";
+      },
+    },
+    {
+      code: "JWK_USE_INVALID",
+      mutate(input) {
+        input.trust.jwsKeys[0].publicJwk.use = "enc";
+      },
+    },
+    {
+      code: "JWK_KEY_OPS_INVALID",
+      mutate(input) {
+        input.trust.jwsKeys[0].publicJwk.key_ops = ["sign"];
+      },
+    },
+  ];
+
+  for (const testCase of cases) {
+    const input = fixture("jws-valid.json");
+    testCase.mutate(input);
+    const result = runVerifier(input);
+
+    assert.equal(result.status, 2, result.stderr || result.stdout);
+    assert.equal(hasError(result, testCase.code), true);
+  }
+});
+
+test("rejects unsigned duplicate fields on the JWS receipt envelope", () => {
+  const input = fixture("jws-valid.json");
+  input.receipt.payload = { attackerControlled: true };
+
+  const result = runVerifier(input);
+
+  assert.equal(result.status, 2, result.stderr || result.stdout);
+  assert.equal(hasError(result, "UNEXPECTED_RECEIPT_FIELD"), true);
+});
+
+test("enforces resource and transaction binding policy", () => {
+  const wrongResource = fixture("jws-valid.json");
+  wrongResource.policy.expectedResourceUrl =
+    "https://receipts.example.test/other-resource";
+  const resourceResult = runVerifier(wrongResource);
+
+  assert.equal(resourceResult.status, 2, resourceResult.stderr || resourceResult.stdout);
+  assert.equal(hasError(resourceResult, "RESOURCE_URL_MISMATCH"), true);
+
+  const wrongTransaction = fixture("eip712-valid.json");
+  wrongTransaction.policy.expectedTransaction = "fixture-transaction-999";
+  const transactionResult = runVerifier(wrongTransaction);
+
+  assert.equal(
+    transactionResult.status,
+    2,
+    transactionResult.stderr || transactionResult.stdout,
+  );
+  assert.equal(hasError(transactionResult, "TRANSACTION_MISMATCH"), true);
+});


### PR DESCRIPTION
# Summary

Adds a self-contained offline verifier for x402 `offer-receipt` artifacts. It supports EIP-712 and JWS receipts with explicit trust policy, freshness, resource binding, payer/network binding, and transaction-reference checks.

# APIs Used

No HTTP APIs. The skill uses the official `@x402/extensions` package locally. Receipt verification makes no network requests.

# Binaries Used

- Node.js 20 or newer
- npm

# How it works

The verifier reads public-only JSON input, validates a strict version 1 envelope and payload, calls the official x402 package for signature verification, and then independently applies authorization, freshness, binding, and transaction-reference policy. It produces structured JSON output and documented exit codes.

It does not connect a wallet, resolve remote DIDs, query a blockchain, make a payment, or claim that a receipt proves settlement or response quality.

# Use Cases

- Offline receipt validation
- Service-delivery evidence triage
- CI policy checks for signed receipts
- Separating cryptographic signature validity from signer or key authorization

# Validation

- `npm test`: 12 tests passed
- `npm audit --omit=dev`: 0 vulnerabilities
- `npm run verify:jws`: valid receipt and all configured checks passed
