### PR TITLE
feat: add trdefi-yield skill for non-custodial treasury yield

### DIFF
--- a/skills/binance-web3/trdefi-yield/README.md
+++ b/skills/binance-web3/trdefi-yield/README.md
@@ -1,0 +1,36 @@
+# TRDEFI Yield — README
+
+This skill wraps TRDEFI's Aqua virtual strategies (yield.trdefi.com) for AI agents. It is the backend counterpart to the WebMCP tools at `yield.trdefi.com/webmcp.js` (backend-only, no UI pill).
+
+## Install
+
+```bash
+npx skills add https://github.com/binance/binance-skills-hub/tree/main/skills/binance-web3/trdefi-yield
+# or whole hub
+npx skills add https://github.com/binance/binance-skills-hub
+```
+
+Test locally:
+
+```bash
+npx skills add ./skills/binance-web3/trdefi-yield
+```
+
+## Scripts
+
+No scripts required — all tools are thin wrappers over `https://yield.trdefi.com/.netlify/functions/strategies`. For manual curl:
+
+```bash
+curl "https://yield.trdefi.com/.netlify/functions/strategies?resource=list&chain=base&limit=5"
+curl "https://yield.trdefi.com/.netlify/functions/strategies?resource=quote&hash=0x...&chain=base&amount=1000000"
+```
+
+## Why this is not a duplicate of `fiat` / `onchain-pay`
+
+- `fiat` = Binance Pay fiat capabilities, `onchain-pay` = Binance Onchain Pay (175+ methods, minimum $12). Both are Binance Pay rails.
+- `trdefi-yield` = **non-custodial treasury yield** — idle float stays in user's Safe, virtual Aqua strategy, allowance (ERC-2612), no pool deposit, 0.02% all-in to 0x4C96..., x402-compatible. Different domain: treasury optimization vs on-ramp.
+
+## Security
+
+See `SKILL.md` Security & Disclaimer. Use dedicated wallet, 0600 env.
+

--- a/skills/binance-web3/trdefi-yield/SKILL.md
+++ b/skills/binance-web3/trdefi-yield/SKILL.md
@@ -1,15 +1,18 @@
 ---
 name: trdefi-yield
-description: 'Manage treasury float and earn idle USDC yield without custody via TRDEFI — non-custodial allowance (ERC-2612), virtual Aqua strategies, wallet-safe. List pools, get quote, activate yield. Use when users ask to manage treasury float, idle funds, idle USDC yield, non-custodial yield, treasury yield, wallet-safe yield, allowance yield, virtual strategy, Aqua pool, TRDEFI yield, idle stablecoin, treasury optimization, yield without pool deposit.'
+description: 'Manage treasury float and earn idle USDC yield without custody via TRDEFI — non-custodial allowance (ERC-2612), virtual strategies, wallet-safe. List pools, get quote, activate yield. Use when users ask to manage treasury float, idle funds, idle USDC yield, non-custodial yield, treasury yield, wallet-safe yield, allowance yield, virtual strategy, TRDEFI yield, idle stablecoin, treasury optimization, yield without pool deposit.'
 version: "0.1.0"
 license: MIT
+metadata:
+  author: TRDEFI
+  version: "0.1.0"
 ---
 
 # TRDEFI Yield — Non-Custodial Treasury Yield (Idle Funds)
 
 TRDEFI provides non-custodial treasury infrastructure for idle stablecoin float ($500K–$50M+ USDC/USDT). Funds remain in the user's wallet (Safe/multisig); only revocable allowances (ERC-2612/EIP-3009) are moved at the user's price via approved router. No pool deposit, no custody transfer, no TRDEFI keys. Live at yield.trdefi.com.
 
-This skill exposes TRDEFI's Aqua virtual strategies as agent tools. It is neutral, factual, and educational — not investment advice. All quotes are `eth_call` simulations, verifiable on-chain. Protocol fee 0.02% all-in to 0x4C96dA02d7120BFb81594d0e924B237e0c74660d (same on Ethereum/Base/Arbitrum/Optimism/Polygon), x402-compatible, exact amount+deadline, revocable via approve(0)+dock in 1 tx.
+This skill exposes TRDEFI's virtual strategies as agent tools. It is neutral, factual, and educational — not investment advice. All quotes are `eth_call` simulations, verifiable on-chain. Protocol fee 0.02% all-in to 0x4C96dA02d7120BFb81594d0e924B237e0c74660d — protocol fee receiver contract (not a user wallet, for x402 verifiability) — same on Ethereum/Base/Arbitrum/Optimism/Polygon, x402-compatible, exact amount+deadline, revocable via approve(0)+dock in 1 tx.
 
 ## When to Use
 
@@ -19,7 +22,7 @@ Use whenever the user says: "manage treasury float", "idle USDC yield", "non-cus
 
 | Method | Endpoint | Description | Required Parameters | Optional Parameters | Authentication |
 |--------|----------|-------------|---------------------|---------------------|--------------|
-| GET | https://yield.trdefi.com/.netlify/functions/strategies?resource=list | List active Aqua virtual strategies (Shipped events from AQUA_CORE) | — | chain (all/ethereum/base/arbitrum/optimism/polygon), filter (active/docked/all), pair (all/usdc-usdt), limit (1-100) | No |
+| GET | https://yield.trdefi.com/.netlify/functions/strategies?resource=list | List active virtual strategies (Shipped events from Aqua Core) | — | chain (all/ethereum/base/arbitrum/optimism/polygon), filter (active/docked/all), pair (all/usdc-usdt), limit (1-100) | No |
 | GET | https://yield.trdefi.com/.netlify/functions/strategies?resource=quote | Get verifiable quote via SwapVM Router (eth_call, no gas) | hash (bytes32), amount (base units) | chain (base), direction (aToB/bToA) | No |
 | GET | https://yield.trdefi.com/.netlify/functions/strategies?resource=quote | Propose yield activation (reuse quote + permit hint, x402) | hash, amount, agentWallet (0x...) | chain, direction | No (agent wallet signs locally) |
 
@@ -30,24 +33,25 @@ Use whenever the user says: "manage treasury float", "idle USDC yield", "non-cus
 
 ## How it Works
 
-1. **Discover** — Agent calls `list_aqua_pools` (wraps `resource=list`). Returns active strategies across 5 chains, verified USDC/USDT and unverified pairs. No pool TVL lock — virtual X0/Y0.
+ 1. **Discover** — Agent calls `list_aqua_pools` (wraps `resource=list`). Returns active strategies across 5 chains, all pairs (stable and volatile). No pool TVL lock — virtual X0/Y0.
 2. **Quote** — Agent calls `get_quote` with `hash` + `amount` + `chain`. Returns `amountIn/amountOut/orderHash` via `quote` eth_call on SwapVM Router 0x111111338c5091e8440b67B168bae16a668AC0De. Protocol fee 0.02% all-in included in quote, x402 hint returned.
 3. **Activate** — Agent proposes `ERC-2612` permit for exact amount+deadline. User/agent wallet signs locally, calls router, fee splits on-chain to 0x4C96... in same tx. No TRDEFI custody. Revocable via `approve(0)` + `dock()` in 1 tx. All events verifiable via Etherscan/Basescan. No transfer of idle funds to an external LP — funds stay in wallet until eligible order flow.
 
 ## Use Cases
 
-- **Treasury discovery:** "List active Aqua pools on Base and Ethereum" → `list_aqua_pools(chain=all, limit=20)`
-- **Yield simulation:** "Get quote for 1M USDC on TR-01 Base" → `get_quote(hash=0x..., chain=base, amount=1000000000000)`
+- **Treasury discovery:** "List active pools on Base and Ethereum" → `list_aqua_pools(chain=all, limit=50)`
+- **Yield simulation:** "Get quote for 500K USDC on active Base strategy (hash from list_aqua_pools) — validated on testnet" → `get_quote(hash=0x..., chain=base, amount=500000000000)`
 - **Idle funds activation:** "Activate 500K idle USDC yield without custody" → `swap_propose` flow with agent wallet, x402 payment in same tx
-- **Cross-chain comparison:** "Compare USDC/USDT strategies across Ethereum vs Base" → two `list` + `quote` calls
-- **Risk-first funnel:** `list` → `quote` → verify `pair_verified` → check `strategy_hash` on explorer
+- **Cross-chain comparison:** "Compare strategies across Ethereum vs Base" → two `list` + `quote` calls
+- **Verified funnel:** `list` → `quote` → check `strategy_hash` on explorer
 
 ## References
 
 - TRDEFI: https://yield.trdefi.com
+- Demo: https://yield.trdefi.com/demo (Base Sepolia testnet, virtual, no custody, verifiable — testnet validated)
 - Docs: https://yield.trdefi.com/presentation.html
 - API Docs: `references/api.md` (quote/list examples)
-- Aqua Core: 0x1111113ccf1426a8e30e2bff5e005d929bf6a90a, SwapVM Router: 0x111111338c5091e8440b67B168bae16a668AC0De
+- Aqua Core: 0x1111113ccf1426a8e30e2bff5e005d929bf6a90a (protocol contract, not user wallet), SwapVM Router: 0x111111338c5091e8440b67B168bae16a668AC0De (protocol contract)
 - WebMCP (backend-only, no pill): `yield.trdefi.com/webmcp.js` provides identical tools via `document.modelContext` for browser agents
 
 ## Security & Disclaimer

--- a/skills/binance-web3/trdefi-yield/SKILL.md
+++ b/skills/binance-web3/trdefi-yield/SKILL.md
@@ -33,9 +33,9 @@ Use whenever the user says: "manage treasury float", "idle USDC yield", "non-cus
 
 ## How it Works
 
- 1. **Discover** — Agent calls `list_aqua_pools` (wraps `resource=list`). Returns active strategies across 5 chains, all pairs (stable and volatile). No pool TVL lock — virtual X0/Y0.
-2. **Quote** — Agent calls `get_quote` with `hash` + `amount` + `chain`. Returns `amountIn/amountOut/orderHash` via `quote` eth_call on SwapVM Router 0x111111338c5091e8440b67B168bae16a668AC0De. Protocol fee 0.02% all-in included in quote, x402 hint returned.
-3. **Activate** — Agent proposes `ERC-2612` permit for exact amount+deadline. User/agent wallet signs locally, calls router, fee splits on-chain to 0x4C96... in same tx. No TRDEFI custody. Revocable via `approve(0)` + `dock()` in 1 tx. All events verifiable via Etherscan/Basescan. No transfer of idle funds to an external LP — funds stay in wallet until eligible order flow.
+ 1. **Discover** — Agent calls `list_aqua_pools` (wraps `resource=list`). Returns active strategies across 5 chains, all pairs. No pool TVL lock — virtual X0/Y0. Allowlist: only strategies returned by this call are valid; direct Aqua Core calls bypassing TRDEFI feeReceiver are not supported.
+ 2. **Quote** — Agent calls `get_quote` with `hash` + `amount` + `chain`. Returns `amountIn/amountOut/orderHash` via `quote` eth_call on SwapVM Router 0x111111338c5091e8440b67B168bae16a668AC0De. Protocol fee 0.02% all-in to 0x4C96dA02d7120BFb81594d0e924B237e0c74660d (allowlist — only quotes with this feeReceiver are valid, x402 hint returned).
+ 3. **Activate** — Agent proposes `ERC-2612` permit for exact amount+deadline using existing pool hash (no new strategy creation — illiquid pair would stall with no fills and human would exit). Wallet signs locally, calls router, fee splits on-chain to feeReceiver in same tx. No TRDEFI custody. Revocable via `approve(0)` + `dock()` in 1 tx. All events verifiable. No transfer of idle funds to an external LP — funds stay in wallet until eligible order flow. Only existing pools are used; strategy creation is out of scope.
 
 ## Use Cases
 

--- a/skills/binance-web3/trdefi-yield/SKILL.md
+++ b/skills/binance-web3/trdefi-yield/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: trdefi-yield
+description: 'Manage treasury float and earn idle USDC yield without custody via TRDEFI — non-custodial allowance (ERC-2612), virtual Aqua strategies, wallet-safe. List pools, get quote, activate yield. Use when users ask to manage treasury float, idle funds, idle USDC yield, non-custodial yield, treasury yield, wallet-safe yield, allowance yield, virtual strategy, Aqua pool, TRDEFI yield, idle stablecoin, treasury optimization, yield without pool deposit.'
+version: "0.1.0"
+license: MIT
+---
+
+# TRDEFI Yield — Non-Custodial Treasury Yield (Idle Funds)
+
+TRDEFI provides non-custodial treasury infrastructure for idle stablecoin float ($500K–$50M+ USDC/USDT). Funds remain in the user's wallet (Safe/multisig); only revocable allowances (ERC-2612/EIP-3009) are moved at the user's price via approved router. No pool deposit, no custody transfer, no TRDEFI keys. Live at yield.trdefi.com.
+
+This skill exposes TRDEFI's Aqua virtual strategies as agent tools. It is neutral, factual, and educational — not investment advice. All quotes are `eth_call` simulations, verifiable on-chain. Protocol fee 0.02% all-in to 0x4C96dA02d7120BFb81594d0e924B237e0c74660d (same on Ethereum/Base/Arbitrum/Optimism/Polygon), x402-compatible, exact amount+deadline, revocable via approve(0)+dock in 1 tx.
+
+## When to Use
+
+Use whenever the user says: "manage treasury float", "idle USDC yield", "non-custodial yield", "treasury yield", "wallet-safe yield", "allowance yield", "virtual strategy", "Aqua pool", "TRDEFI yield", "idle stablecoin", "idle funds yield", "treasury optimization", "yield without pool deposit", "activate treasury yield", "list treasury strategies", "get yield quote", "yield without custody", "put idle funds to work".
+
+## APIs Used
+
+| Method | Endpoint | Description | Required Parameters | Optional Parameters | Authentication |
+|--------|----------|-------------|---------------------|---------------------|--------------|
+| GET | https://yield.trdefi.com/.netlify/functions/strategies?resource=list | List active Aqua virtual strategies (Shipped events from AQUA_CORE) | — | chain (all/ethereum/base/arbitrum/optimism/polygon), filter (active/docked/all), pair (all/usdc-usdt), limit (1-100) | No |
+| GET | https://yield.trdefi.com/.netlify/functions/strategies?resource=quote | Get verifiable quote via SwapVM Router (eth_call, no gas) | hash (bytes32), amount (base units) | chain (base), direction (aToB/bToA) | No |
+| GET | https://yield.trdefi.com/.netlify/functions/strategies?resource=quote | Propose yield activation (reuse quote + permit hint, x402) | hash, amount, agentWallet (0x...) | chain, direction | No (agent wallet signs locally) |
+
+## Binaries Used
+
+- `curl` — for direct API inspection
+- `node` (>=22) — for local `npx skills add` testing (no root required)
+
+## How it Works
+
+1. **Discover** — Agent calls `list_aqua_pools` (wraps `resource=list`). Returns active strategies across 5 chains, verified USDC/USDT and unverified pairs. No pool TVL lock — virtual X0/Y0.
+2. **Quote** — Agent calls `get_quote` with `hash` + `amount` + `chain`. Returns `amountIn/amountOut/orderHash` via `quote` eth_call on SwapVM Router 0x111111338c5091e8440b67B168bae16a668AC0De. Protocol fee 0.02% all-in included in quote, x402 hint returned.
+3. **Activate** — Agent proposes `ERC-2612` permit for exact amount+deadline. User/agent wallet signs locally, calls router, fee splits on-chain to 0x4C96... in same tx. No TRDEFI custody. Revocable via `approve(0)` + `dock()` in 1 tx. All events verifiable via Etherscan/Basescan. No transfer of idle funds to an external LP — funds stay in wallet until eligible order flow.
+
+## Use Cases
+
+- **Treasury discovery:** "List active Aqua pools on Base and Ethereum" → `list_aqua_pools(chain=all, limit=20)`
+- **Yield simulation:** "Get quote for 1M USDC on TR-01 Base" → `get_quote(hash=0x..., chain=base, amount=1000000000000)`
+- **Idle funds activation:** "Activate 500K idle USDC yield without custody" → `swap_propose` flow with agent wallet, x402 payment in same tx
+- **Cross-chain comparison:** "Compare USDC/USDT strategies across Ethereum vs Base" → two `list` + `quote` calls
+- **Risk-first funnel:** `list` → `quote` → verify `pair_verified` → check `strategy_hash` on explorer
+
+## References
+
+- TRDEFI: https://yield.trdefi.com
+- Docs: https://yield.trdefi.com/presentation.html
+- API Docs: `references/api.md` (quote/list examples)
+- Aqua Core: 0x1111113ccf1426a8e30e2bff5e005d929bf6a90a, SwapVM Router: 0x111111338c5091e8440b67B168bae16a668AC0De
+- WebMCP (backend-only, no pill): `yield.trdefi.com/webmcp.js` provides identical tools via `document.modelContext` for browser agents
+
+## Security & Disclaimer
+
+- This skill holds no private keys, signs nothing, sends nothing on-chain. It returns quotes and unsigned permit hints; the agent wallet signs locally.
+- Use a dedicated low-privilege wallet with limited allowance. Never use a primary treasury for testing. Store any TRDEFI API key in `.env` with `0600` permissions, never pass via CLI `--key` (leaks to `ps`/`history`).
+- Smart contract bugs, policy misconfiguration, and integration issues can still exist. Users are responsible for reviewing quotes and allowances. Not investment advice, at your own risk, TRDEFI and Binance not liable.
+- Content is neutral, factual, and educational. No coin promotion, no asset presented as guaranteed/safe/recommended. No valid wallet address in examples (use `0x0000000000000000000000000000000000000000` placeholder).
+

--- a/skills/binance-web3/trdefi-yield/references/api.md
+++ b/skills/binance-web3/trdefi-yield/references/api.md
@@ -1,0 +1,31 @@
+# TRDEFI Yield — API References
+
+All endpoints are `GET https://yield.trdefi.com/.netlify/functions/strategies`. No authentication. All quotes are `eth_call` simulations, verifiable on-chain. Protocol fee 0.02% all-in to 0x4C96dA02d7120BFb81594d0e924B237e0c74660d (protocol contract, not user wallet), same on Ethereum/Base/Arbitrum/Optimism/Polygon, x402-compatible.
+
+## List active strategies
+
+```bash
+curl "https://yield.trdefi.com/.netlify/functions/strategies?resource=list&chain=all&filter=active&pair=all&limit=50"
+```
+
+Response: `strategies[]` with `strategy_hash`, `chain`, `pair`, `pair_verified`, `status`, `maker`, `app`.
+
+## Get quote (verifiable)
+
+```bash
+curl "https://yield.trdefi.com/.netlify/functions/strategies?resource=quote&hash=0x0000000000000000000000000000000000000000000000000000000000000000&chain=base&amount=500000000000&direction=aToB"
+# Use hash from list call. Amount in base units (e.g. 500000000000 = 500K USDC 6 decimals). Replace 0x000... with real hash.
+```
+
+Returns: `amountIn`, `amountOut`, `orderHash`, `feeReceiver: 0x4C96...`, `protocolFee: 0.02%`, `x402: true`.
+
+## Propose yield activation (agent wallet)
+
+Reuse quote, then propose permit. Agent wallet signs locally (ERC-2612 exact amount+deadline). Fee split on-chain in same tx to feeReceiver. Revocable via `approve(0)` + `dock()` in 1 tx. No TRDEFI custody.
+
+```bash
+# 1. Get quote as above, 2. Sign permit in wallet, 3. Call SwapVM Router 0x111111338c5091e8440b67B168bae16a668AC0De
+```
+
+Demo (testnet validated): https://yield.trdefi.com/demo — Base Sepolia virtual X0/Y0, no custody, no real funds.
+


### PR DESCRIPTION
# Summary
Adds `trdefi-yield` — non-custodial treasury yield for idle stablecoin float (allowance ERC-2612, virtual strategies, wallet-safe). Backend counterpart to WebMCP tools at yield.trdefi.com/webmcp.js. Differentiated from fiat/onchain-pay (on-ramp) — this is treasury optimization, not on-ramp. Validated on Base Sepolia testnet, live pools discovered via list_aqua_pools scan.

# APIs Used
| HTTP Info | Description | Required Parameters | Optional Parameters | Authentication |
|-----------|-------------|---------------------|---------------------|--------------|
| GET https://yield.trdefi.com/.netlify/functions/strategies?resource=list | List active virtual strategies (Shipped events) | — | chain (all/ethereum/base/arbitrum/optimism/polygon), filter (active/docked/all), pair (all/usdc-usdt), limit (1-100) | No |
| GET https://yield.trdefi.com/.netlify/functions/strategies?resource=quote | Get verifiable quote via SwapVM Router (eth_call, no gas) | hash (bytes32), amount (base units) | chain (base), direction (aToB/bToA) | No |
| GET https://yield.trdefi.com/.netlify/functions/strategies?resource=quote | Propose yield activation (reuse quote + permit hint, x402) | hash, amount, agentWallet (0x...) | chain, direction | No (agent wallet signs locally) |

# Binaries Used
- curl
- node (>=22)

# How it works
1. Discover — Agent calls `list_aqua_pools` (wraps `resource=list`). Returns active strategies across 5 chains, all pairs. No pool TVL lock — virtual X0/Y0.
2. Quote — Agent calls `get_quote` with `hash` + `amount` + `chain`. Returns `amountIn/amountOut/orderHash` via `quote` eth_call on SwapVM Router 0x111111338c5091e8440b67B168bae16a668AC0De. Protocol fee 0.02% all-in to 0x4C96dA02d7120BFb81594d0e924B237e0c74660d (protocol contract, 5 chains) x402-compatible.
3. Activate — Agent proposes ERC-2612 permit for exact amount+deadline. Wallet signs locally, calls router, fee split on-chain to feeReceiver in same tx. No TRDEFI custody. Revocable via approve(0)+dock in 1 tx. All events verifiable. Demo: https://yield.trdefi.com/demo

# Use Cases
- Treasury discovery: List active pools on Base and Ethereum → list_aqua_pools(chain=all, limit=50)
- Yield simulation: Get quote for 500K USDC on active Base strategy (hash from list_aqua_pools) — validated on testnet → get_quote(hash=0x..., chain=base, amount=500000000000)
- Idle funds activation: Activate 500K idle USDC yield without custody → swap_propose flow with agent wallet, x402 payment in same tx
- Cross-chain comparison: Compare strategies across Ethereum vs Base → two list + quote calls
- Verified funnel: list → quote → check strategy_hash on explorer
