### PR TITLE
feat: add radarcrypto-btc-score skill

### DIFF
--- a/skills/radarcrypto-btc-score/SKILL.md
+++ b/skills/radarcrypto-btc-score/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: radarcrypto-btc-score
+description: |
+  Composite Bitcoin market-state snapshot from a single public endpoint: a 0-100 score,
+  five weighted sub-scores (trend, derivatives, momentum, flow, risk) and ~40 underlying
+  indicators - funding rate, open interest, long/short and taker ratios, RSI, MACD,
+  moving averages, BTC/ETH dominance, Fear & Greed, DXY and SPY correlation.
+  Use when the user asks what current BTC market conditions look like, wants derivatives
+  positioning or momentum context, or when an agent needs one machine-readable snapshot
+  of BTC market state instead of querying several data sources separately.
+metadata:
+  author: wendersonalves1982-oss
+  version: "1.0"
+license: MIT
+---
+
+# RadarCrypto BTC Score
+
+Reads a single public JSON endpoint that aggregates Bitcoin market data into a composite
+score plus the indicators behind it. No API key. Updated every 2 minutes.
+
+This skill reports market state. It does not recommend any action, asset or position.
+
+## Usage
+
+```bash
+node scripts/cli.mjs score        # composite score, zone and price
+node scripts/cli.mjs subscores    # the five weighted dimensions
+node scripts/cli.mjs indicators   # all raw indicators
+node scripts/cli.mjs full         # everything, human readable
+node scripts/cli.mjs json         # raw JSON, for piping
+```
+
+Endpoint: `https://radarcrypto.com.br/api/indicators.json`
+Set `RADARCRYPTO_API` to point at a different host.
+
+## Score zones
+
+The composite score is bucketed into three descriptive zones. The labels describe the
+model's reading of current conditions - they are not instructions.
+
+| Range | Zone label | What it describes |
+|-------|-----------|-------------------|
+| 0-39 | RISCO | Indicators are predominantly stressed |
+| 40-69 | NEUTRO | Indicators are mixed or offsetting |
+| 70-100 | COMPRA | Indicators are predominantly constructive |
+
+Zone labels come from the upstream model and are Portuguese strings (`RISCO`, `NEUTRO`, `COMPRA`). They are the model's own naming for each band, not a recommendation from this skill. `risk_signal` carries a second short label for the same reading.
+`capitulation.active` marks conditions the model classifies as forced selling, with the
+triggering reasons listed in `capitulation.reasons`.
+
+## Sub-scores
+
+Five dimensions, each 0-100, combined into the headline score:
+
+- `tendencia` - moving-average structure and alignment
+- `derivativos` - funding, open interest, long/short and taker ratios
+- `momentum` - RSI and MACD state
+- `fluxo` - dominance shifts and market-cap flow
+- `risco` - macro and correlation stress (DXY, SPY correlation)
+
+Reading them separately shows what moved the headline: a 61 driven by strong trend but
+weak risk describes a different market than the reverse.
+
+## Response shape
+
+```json
+{
+  "updated_at": "2026-08-30T13:32:06Z",
+  "engine_version": "4.0",
+  "score": 61,
+  "score_zone": "NEUTRO",
+  "score_range": "40-69",
+  "risk_signal": "AGUARDAR",
+  "capitulation": { "active": false, "reasons": [], "text": null },
+  "sub_scores": { "tendencia": 70, "derivativos": 53, "momentum": 68, "fluxo": 57, "risco": 41 },
+  "indicators": { "btc_price": 78686.2, "funding_rate": 0.000094, "rsi": 68, "...": "~40 fields" }
+}
+```
+
+## Notes
+
+- Requires Node >= 18 (global `fetch`). Zero dependencies. Runs unprivileged.
+- Some `indicators` fields are Portuguese human-readable labels (`funding_status`,
+  `ls_status`); all numeric fields are language-neutral.
+- Informational and educational only. Not financial advice.

--- a/skills/radarcrypto-btc-score/references/cli.md
+++ b/skills/radarcrypto-btc-score/references/cli.md
@@ -1,0 +1,56 @@
+# cli.mjs
+
+Helper script for the `radarcrypto-btc-score` skill.
+
+## What it does
+
+Fetches `https://radarcrypto.com.br/api/indicators.json` and prints the composite BTC
+score, its five sub-scores and the underlying indicators in a readable form.
+
+## Requirements
+
+Node >= 18. No dependencies, no install step, no privileged access.
+
+## Commands
+
+| Command | Output |
+|---------|--------|
+| `node scripts/cli.mjs score` | Composite score, zone, signal label, price |
+| `node scripts/cli.mjs subscores` | Score plus the five weighted dimensions |
+| `node scripts/cli.mjs indicators` | Score plus every raw indicator field |
+| `node scripts/cli.mjs full` | All of the above |
+| `node scripts/cli.mjs json` | Raw JSON, unformatted, for piping |
+
+Defaults to `score` when no command is given.
+
+## Configuration
+
+`RADARCRYPTO_API` overrides the endpoint URL.
+
+```bash
+RADARCRYPTO_API=https://example.com/indicators.json node scripts/cli.mjs full
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Network or API error (message on stderr) |
+| 2 | Unknown command |
+
+## Sample output
+
+```
+BTC Score: 61/100  .  NEUTRO (40-69)
+Sinal: AGUARDAR
+Preco: $78,686  +1.33%
+Atualizado: 2026-08-30T13:32:06Z  (engine 4.0)
+
+Sub-scores:
+  tendencia                70
+  derivativos              53
+  momentum                 68
+  fluxo                    57
+  risco                    41
+```

--- a/skills/radarcrypto-btc-score/scripts/cli.mjs
+++ b/skills/radarcrypto-btc-score/scripts/cli.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// RadarCrypto BTC Score — CLI (sem dependencias, Node >= 18)
+const API = process.env.RADARCRYPTO_API || 'https://radarcrypto.com.br/api/indicators.json';
+
+async function load() {
+  const r = await fetch(API + '?_t=' + Date.now(), { headers: { 'accept': 'application/json' } });
+  if (!r.ok) throw new Error(`API ${r.status} ${r.statusText}`);
+  return r.json();
+}
+
+const fmt = (v) => v === null || v === undefined ? '—' : (typeof v === 'number' ? String(v) : String(v));
+
+function printKV(obj, indent = '  ') {
+  for (const [k, v] of Object.entries(obj)) {
+    if (v && typeof v === 'object' && !Array.isArray(v)) { console.log(`${indent}${k}:`); printKV(v, indent + '  '); }
+    else console.log(`${indent}${k.padEnd(24)} ${fmt(Array.isArray(v) ? v.join(', ') : v)}`);
+  }
+}
+
+function score(d) {
+  console.log(`\nBTC Score: ${d.score}/100  ·  ${d.score_zone} (${d.score_range})`);
+  console.log(`Sinal: ${d.risk_signal}`);
+  if (d.indicators?.btc_price_fmt) console.log(`Preco: ${d.indicators.btc_price_fmt}  ${d.indicators.change_24h_fmt || ''}`);
+  if (d.capitulation?.active) console.log(`CAPITULACAO: ${d.capitulation.text || d.capitulation.reasons?.join('; ')}`);
+  console.log(`Atualizado: ${d.updated_at}  (engine ${d.engine_version})\n`);
+}
+
+function sub(d) { console.log('\nSub-scores:'); printKV(d.sub_scores || {}); console.log(); }
+function ind(d) { console.log('\nIndicadores:'); printKV(d.indicators || {}); console.log(); }
+
+const cmd = process.argv[2] || 'score';
+try {
+  const d = await load();
+  if (cmd === 'json') console.log(JSON.stringify(d, null, 2));
+  else if (cmd === 'indicators') { score(d); ind(d); }
+  else if (cmd === 'subscores') { score(d); sub(d); }
+  else if (cmd === 'full') { score(d); sub(d); ind(d); }
+  else if (cmd === 'score') score(d);
+  else { console.error('Uso: cli.mjs [score|subscores|indicators|full|json]'); process.exit(2); }
+} catch (e) { console.error('Erro:', e.message); process.exit(1); }


### PR DESCRIPTION
Adds a skill that exposes a composite Bitcoin market-state snapshot from a single public JSON endpoint.

### What it provides

- Composite score 0-100 with a zone label
- Five weighted sub-scores: trend, derivatives, momentum, flow, risk
- ~40 raw indicators: funding rate, open interest, long/short and taker ratios, RSI, MACD, moving averages, BTC/ETH dominance, Fear & Greed, DXY, SPY correlation
- A forced-selling flag with the reasons that triggered it

The value over calling several data sources separately is that everything arrives in one shape, already reconciled to the same timestamp, so an agent can answer "what does BTC look like right now" in one call.

### Structure

```
skills/radarcrypto-btc-score/
├── SKILL.md
├── references/cli.md
└── scripts/cli.mjs
```

### Notes on the guidelines

- No dependencies, no install step, runs unprivileged (Node >= 18, global `fetch`)
- No wallet addresses, no token promotion, no asset presented as safe or recommended
- Zone labels (`RISCO`, `NEUTRO`, `COMPRA`) come from the upstream model; SKILL.md states explicitly that they are the model's own band naming and not a recommendation from the skill
- SKILL.md and references/cli.md both carry the informational-only disclaimer

### Verification

`node scripts/cli.mjs score|subscores|indicators|full|json` all run against the live endpoint.
