### PR TITLE
Add charter skill

### DIFF
--- a/skills/charter/README.md
+++ b/skills/charter/README.md
@@ -1,0 +1,16 @@
+# charter
+
+A Skill Hub skill for calling [CHARTER](https://github.com/angelraph/charter) — a mandate/policy layer that vets an agent's trade proposals against a human-defined covenant before they execute.
+
+See [`skill.md`](./skill.md) for the full instructions an agent follows to use this skill, and [`references/`](./references) for the exact request/response JSON shapes.
+
+## Local setup (to run CHARTER yourself)
+
+```bash
+git clone https://github.com/angelraph/charter
+cd charter
+npm install
+cp .env.example .env   # fill in your Binance testnet (or mainnet MCP) credentials
+npm run dev init        # activates the demo mandate
+npx tsx src/index.ts serve   # starts the API this skill calls
+```

--- a/skills/charter/references/proposal-schema.json
+++ b/skills/charter/references/proposal-schema.json
@@ -1,0 +1,27 @@
+{
+  "description": "Request body for POST /propose",
+  "type": "object",
+  "required": ["agentId", "mandateId", "symbol", "side", "usd"],
+  "properties": {
+    "agentId": { "type": "string", "description": "Identifier of the agent making the proposal" },
+    "mandateId": { "type": "string", "format": "uuid", "description": "Which active mandate to evaluate against" },
+    "symbol": { "type": "string", "example": "BTCUSDT" },
+    "side": { "type": "string", "enum": ["BUY", "SELL"] },
+    "usd": { "type": "number", "exclusiveMinimum": 0, "description": "Notional size in USD (quote asset)" },
+    "reason": { "type": "string", "description": "Optional free-text reason, shown in the audit log" },
+    "execute": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, place the real order immediately on a PASS verdict (or a human-confirmed ESCALATE)"
+    }
+  },
+  "example": {
+    "agentId": "my-agent",
+    "mandateId": "b2f1e9a0-1a2b-4c3d-8e4f-000000000001",
+    "symbol": "BTCUSDT",
+    "side": "BUY",
+    "usd": 25,
+    "reason": "momentum signal crossed threshold",
+    "execute": false
+  }
+}

--- a/skills/charter/references/verdict-schema.json
+++ b/skills/charter/references/verdict-schema.json
@@ -1,0 +1,51 @@
+{
+  "description": "Response body for POST /propose and GET /status/:id",
+  "type": "object",
+  "properties": {
+    "proposalId": { "type": "string", "format": "uuid" },
+    "verdict": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "decision": { "type": "string", "enum": ["PASS", "VETO", "ESCALATE"] },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rule": { "type": "string", "example": "spendingCap" },
+              "outcome": { "type": "string", "enum": ["ok", "violated", "warning"] },
+              "detail": { "type": "string" }
+            }
+          }
+        },
+        "simulation": {
+          "type": "object",
+          "properties": {
+            "venue": { "type": "string", "example": "testnet" },
+            "referencePrice": { "type": "number" },
+            "projectedFillPrice": { "type": "number" },
+            "projectedSlippageBps": { "type": "number" },
+            "notionalUsd": { "type": "number" },
+            "projectedNavImpactPct": { "type": "number" },
+            "orderBookDepthSampledAt": { "type": "string", "format": "date-time" }
+          }
+        },
+        "decidedAt": { "type": "string", "format": "date-time" },
+        "policyVersion": { "type": "integer" }
+      }
+    },
+    "execution": {
+      "type": ["object", "null"],
+      "description": "Present only if execute:true was set and the verdict allowed execution",
+      "properties": {
+        "orderId": { "type": "string" },
+        "symbol": { "type": "string" },
+        "side": { "type": "string", "enum": ["BUY", "SELL"] },
+        "status": { "type": "string" },
+        "executedQty": { "type": "number" },
+        "cummulativeQuoteQty": { "type": "number" }
+      }
+    }
+  }
+}

--- a/skills/charter/scripts/example-client.js
+++ b/skills/charter/scripts/example-client.js
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 /**
- * Minimal example: propose a trade to a locally running CHARTER instance
+ * Minimal example: propose a trade to a running CHARTER instance
  * (`charter serve`, default port 4477) and print the verdict.
  *
  * Usage: node example-client.js <mandateId> <symbol> <side> <usd>
+ *
+ * Set CHARTER_BASE_URL to point at a remote instance instead of localhost.
+ * Set CHARTER_API_KEY if the instance requires the X-Charter-Api-Key header.
  */
 
 const [, , mandateId, symbol, side, usdStr] = process.argv;
@@ -13,9 +16,15 @@ if (!mandateId || !symbol || !side || !usdStr) {
   process.exit(1);
 }
 
-const res = await fetch("http://localhost:4477/propose", {
+const baseUrl = process.env.CHARTER_BASE_URL ?? "http://localhost:4477";
+const apiKey = process.env.CHARTER_API_KEY;
+
+const res = await fetch(`${baseUrl}/propose`, {
   method: "POST",
-  headers: { "Content-Type": "application/json" },
+  headers: {
+    "Content-Type": "application/json",
+    ...(apiKey ? { "X-Charter-Api-Key": apiKey } : {}),
+  },
   body: JSON.stringify({
     agentId: "example-client",
     mandateId,

--- a/skills/charter/scripts/example-client.js
+++ b/skills/charter/scripts/example-client.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * Minimal example: propose a trade to a locally running CHARTER instance
+ * (`charter serve`, default port 4477) and print the verdict.
+ *
+ * Usage: node example-client.js <mandateId> <symbol> <side> <usd>
+ */
+
+const [, , mandateId, symbol, side, usdStr] = process.argv;
+
+if (!mandateId || !symbol || !side || !usdStr) {
+  console.error("Usage: node example-client.js <mandateId> <symbol> <side> <usd>");
+  process.exit(1);
+}
+
+const res = await fetch("http://localhost:4477/propose", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    agentId: "example-client",
+    mandateId,
+    symbol,
+    side,
+    usd: parseFloat(usdStr),
+    reason: "example-client.js",
+    execute: false,
+  }),
+});
+
+const body = await res.json();
+console.log(JSON.stringify(body, null, 2));

--- a/skills/charter/skill.md
+++ b/skills/charter/skill.md
@@ -17,7 +17,7 @@ If your agent already decides what to trade, CHARTER decides whether it is allow
 
 ## Calling CHARTER
 
-CHARTER exposes a local HTTP API (`charter serve`). All three calls below are plain JSON over HTTP. No SDK is required.
+CHARTER exposes an HTTP API (`charter serve`). All three calls below are plain JSON over HTTP. No SDK is required. If the instance you are calling was started with `CHARTER_API_KEY` set, include it on every request as an `X-Charter-Api-Key` header.
 
 ### charter.propose
 

--- a/skills/charter/skill.md
+++ b/skills/charter/skill.md
@@ -1,0 +1,86 @@
+---
+name: charter
+description: Submit a proposed trade to CHARTER for a real PASS/VETO/ESCALATE mandate-compliance verdict, simulated against live market data, before it executes.
+version: 0.1.0
+license: MIT
+---
+
+# CHARTER
+
+CHARTER is not a trading agent. It is a mandate and policy layer that other agents' trade proposals must pass through before they can execute. A human writes a plain-English covenant (spend caps, symbol allowlist, leverage limits, daily drawdown halt, confirm-above-$X). CHARTER compiles that into a live policy, simulates every proposal against the real order book, and returns a real PASS, VETO, or ESCALATE verdict. Only a PASS, or a human-confirmed ESCALATE, ever reaches an execution venue. Every step is written to a tamper-evident, hash-chained audit log.
+
+Repo: https://github.com/angelraph/charter
+
+## Why an agent would use this
+
+If your agent already decides what to trade, CHARTER decides whether it is allowed to. Instead of calling a trading venue directly, route the proposal through CHARTER first and get a real accept or reject decision grounded in the user's own stated limits and live market conditions, rather than a static allowlist you have to maintain yourself.
+
+## Calling CHARTER
+
+CHARTER exposes a local HTTP API (`charter serve`). All three calls below are plain JSON over HTTP. No SDK is required.
+
+### charter.propose
+
+Submit a trade for a verdict.
+
+```bash
+curl -s -X POST http://localhost:4477/propose \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "my-agent",
+    "mandateId": "<mandate-id>",
+    "symbol": "BTCUSDT",
+    "side": "BUY",
+    "usd": 25,
+    "reason": "momentum signal crossed threshold",
+    "execute": false
+  }'
+```
+
+Response:
+
+```json
+{
+  "proposalId": "7b934dba-3aaa-4317-a0c8-e8301e260e65",
+  "verdict": {
+    "decision": "PASS",
+    "reasons": [{ "rule": "spendingCap", "outcome": "ok", "detail": "Notional $25.00 is within the daily cap" }],
+    "simulation": { "referencePrice": 77584.63, "projectedSlippageBps": 0, "notionalUsd": 25 }
+  },
+  "execution": null
+}
+```
+
+Set `"execute": true` to have CHARTER place the real order immediately when the verdict is `PASS`, or when you are supplying human confirmation for an `ESCALATE`. Leave it `false` for a dry-run verdict only.
+
+### charter.status
+
+Check a previously submitted proposal.
+
+```bash
+curl -s http://localhost:4477/status/<proposalId>
+```
+
+### charter.mandate
+
+Read the currently active covenant and its limits.
+
+```bash
+curl -s "http://localhost:4477/mandate?id=<mandate-id>"
+```
+
+## Verdict semantics
+
+- **PASS**: every rule satisfied. Execution proceeds automatically if `execute: true` was set.
+- **VETO**: at least one rule was violated (oversized order, disallowed symbol, drawdown halt tripped, and so on). No order is ever placed for a VETO. CHARTER's audit log shows no execution attempt at all for a vetoed proposal.
+- **ESCALATE**: no rule was violated, but the order crosses the mandate's `confirmAboveUsd` threshold. CHARTER will not execute this without an explicit `execute: true` on a follow-up call, standing in for a human's confirmation.
+
+## What CHARTER will not do
+
+CHARTER does not promote, recommend, or guarantee the safety of any asset. The symbol and side you send are proposed by your agent, not suggested by CHARTER. CHARTER never handles wallet addresses or private keys. Execution runs entirely through the connected exchange venue's own order-placement API.
+
+## References
+
+- `references/proposal-schema.json`: full Proposal request shape
+- `references/verdict-schema.json`: full Verdict response shape
+- `scripts/example-client.js`: minimal Node example calling `/propose`


### PR DESCRIPTION
CHARTER is a mandate and policy layer for AI trading agents. Other agents' trade proposals have to pass through it before they can reach an execution venue.

A human writes a covenant in plain English: spend caps, a symbol allowlist, leverage limits, a daily drawdown halt, a confirm-above threshold. CHARTER compiles that into a live policy, simulates every proposal against real market data, and returns a PASS, VETO, or ESCALATE verdict. Only a PASS, or a human-confirmed ESCALATE, reaches execution. Every step is written to a hash-chained audit log.

This skill documents the three calls an agent makes to CHARTER's local HTTP API: charter.propose, charter.status, and charter.mandate. References include the full request and response schemas and a minimal example client, verified against a running instance.

Repo: https://github.com/angelraph/charter