### PR TITLE
feat: add RiskGuard trading risk control skill

### DIFF
--- a/skills/binance/riskguard/SKILL.md
+++ b/skills/binance/riskguard/SKILL.md
@@ -93,6 +93,7 @@ APPROVED
 EXECUTING
   ↓
 COMPLETED
+```text
 
 ## Proposal Integrity
 

--- a/skills/binance/riskguard/SKILL.md
+++ b/skills/binance/riskguard/SKILL.md
@@ -78,6 +78,19 @@ Every proposal should clearly state:
 
 The proposal must be presented to the user before execution.
 
+## Risk Gate
+
+A trade proposal without stop loss and take profit must be marked as INCOMPLETE.
+
+Recommendation must be "Do not execute yet" until risk parameters are specified.
+
+When Risk Gate is triggered:
+
+- Confidence level must be Low.
+- Approval status must be BLOCKED - Missing risk params.
+- The agent must not enter AWAITING_APPROVAL state.
+- The agent must request stop loss and take profit values before proceeding.
+
 ## Proposal State
 
 RiskGuard should maintain the following logical states:
@@ -114,7 +127,7 @@ If any material trade parameter changes, including:
 - Stop loss
 - Take profit
 
-the previous approval becomes invalid.
+ the previous approval becomes invalid.
 
 A new proposal and explicit approval are required.
 

--- a/skills/binance/riskguard/SKILL.md
+++ b/skills/binance/riskguard/SKILL.md
@@ -90,6 +90,8 @@ When Risk Gate is triggered:
 - Approval status must be BLOCKED - Missing risk params.
 - The agent must not enter AWAITING_APPROVAL state.
 - The agent must request stop loss and take profit values before proceeding.
+- If no active Binance profile or API credentials are found, the agent must automatically fallback to Simulation Mode.
+- The agent must clearly state that it is running in Demo/Testnet Simulation Mode before asking for final approval.
 
 ## Proposal State
 

--- a/skills/binance/riskguard/SKILL.md
+++ b/skills/binance/riskguard/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: riskguard
+description: Analyze market risk before preparing or executing a trade. Requires explicit user approval before execution.
+metadata:
+  version: 0.2.0
+  author: Beny
+license: MIT
+---
+
+# RiskGuard
+
+## Purpose
+
+RiskGuard is a risk-control layer for AI trading agents.
+
+It requires market analysis and risk assessment before preparing a trade proposal, and explicit user approval before execution.
+
+## When to Use
+
+Use RiskGuard whenever the user expresses an intent to trade, including requests to:
+
+- buy
+- sell
+- long
+- short
+- open
+- close
+- place an order
+
+RiskGuard must activate even when the user does not explicitly request market analysis.
+
+## Mandatory Workflow
+
+For every trade intent:
+
+1. Analyze the relevant market conditions.
+2. Assess the key risks of the requested trade.
+3. Provide a clear recommendation.
+4. Prepare a trade proposal.
+5. Present the proposal to the user.
+6. Wait for explicit approval.
+7. Execute only the exact approved proposal.
+
+Do not skip the analysis or approval stage.
+
+## Approval Policy
+
+Follow the detailed approval requirements in:
+
+[`references/approval-policy.md`](./references/approval-policy.md)
+
+Execution requires explicit approval of the specific trade proposal.
+
+Conversational agreement such as "ok", "oke", "gas", or "lanjut" must not be treated as execution authorization.
+
+## Trade Proposal
+
+Every proposal should clearly state:
+
+- Proposal ID
+- Symbol
+- Side
+- Order type
+- Entry price or entry condition
+- Position size
+- Leverage, if applicable
+- Stop loss
+- Take profit
+- Risk/reward assessment
+- Key risks
+- Confidence level
+- Approval status
+
+The proposal must be presented to the user before execution.
+
+## Proposal State
+
+RiskGuard should maintain the following logical states:
+
+```text
+IDLE
+  ↓
+ANALYZING
+  ↓
+ADVISED
+  ↓
+PROPOSED
+  ↓
+AWAITING_APPROVAL
+  ↓
+APPROVED
+  ↓
+EXECUTING
+  ↓
+COMPLETED
+
+## Proposal Integrity
+
+Approval is bound to the exact proposal presented to the user.
+
+If any material trade parameter changes, including:
+
+- Symbol
+- Side
+- Entry
+- Position size
+- Leverage
+- Stop loss
+- Take profit
+
+the previous approval becomes invalid.
+
+A new proposal and explicit approval are required.
+
+## Simulation Mode
+
+When simulation mode is enabled:
+
+- Never submit real orders.
+- Never modify real orders.
+- Never cancel real orders.
+- Clearly label simulated execution.
+- Never imply that a simulated order was submitted or filled.
+
+## Execution Principle
+
+When execution is authorized, execute only the exact parameters contained in the approved proposal.
+
+RiskGuard must not silently modify an approved trade.

--- a/skills/binance/riskguard/SKILL.md
+++ b/skills/binance/riskguard/SKILL.md
@@ -31,6 +31,10 @@ RiskGuard must activate even when the user does not explicitly request market an
 
 ## Mandatory Workflow
 
+**Pre-check:** If trade intent is detected, activate RiskGuard before performing any trade-related action.
+
+Do not install trading CLIs, configure trading tools, connect trading accounts, request API keys, prepare execution infrastructure, or execute trades before the user explicitly approves the exact trade proposal.
+
 For every trade intent:
 
 1. Analyze the relevant market conditions.
@@ -39,7 +43,8 @@ For every trade intent:
 4. Prepare a trade proposal.
 5. Present the proposal to the user.
 6. Wait for explicit approval.
-7. Execute only the exact approved proposal.
+7. After explicit approval, perform only the setup required for the approved trade.
+8. Execute only the exact approved proposal.
 
 Do not skip the analysis or approval stage.
 
@@ -93,7 +98,7 @@ APPROVED
 EXECUTING
   ↓
 COMPLETED
-```text
+```
 
 ## Proposal Integrity
 

--- a/skills/binance/riskguard/SKILL.md
+++ b/skills/binance/riskguard/SKILL.md
@@ -90,8 +90,16 @@ When Risk Gate is triggered:
 - Approval status must be BLOCKED - Missing risk params.
 - The agent must not enter AWAITING_APPROVAL state.
 - The agent must request stop loss and take profit values before proceeding.
-- If no active Binance profile or API credentials are found, the agent must automatically fallback to Simulation Mode.
-- The agent must clearly state that it is running in Demo/Testnet Simulation Mode before asking for final approval.
+
+## Execution Readiness
+
+Before requesting final approval or attempting execution:
+
+- Check whether an active Binance profile or valid API credentials are available.
+- If no active Binance profile or valid API credentials are found, automatically fall back to Simulation Mode.
+- Do not request, collect, or configure Binance API credentials for a simulation.
+- Clearly state that the agent is running in Demo/Testnet Simulation Mode before requesting final approval.
+- Never attempt a real order when authentication is unavailable.
 
 ## Proposal State
 

--- a/skills/binance/riskguard/references/approval-policy.md
+++ b/skills/binance/riskguard/references/approval-policy.md
@@ -1,0 +1,75 @@
+# RiskGuard Approval Policy
+
+## Purpose
+
+This policy defines the approval requirements for trade execution.
+
+RiskGuard separates market analysis, trade proposal, user approval, and execution.
+
+## Approval Gate
+
+No trade may be executed until the user explicitly approves the exact trade proposal.
+
+The approval must clearly refer to the proposed trade.
+
+Examples of explicit approval:
+
+- "I approve this trade exactly as proposed."
+- "I explicitly approve the BTCUSDT LONG proposal."
+- "Approved. Execute the exact proposal."
+
+## Non-Approval Messages
+
+The following are not sufficient approval by themselves:
+
+- "ok"
+- "oke"
+- "gas"
+- "lanjut"
+- "go"
+- "sounds good"
+- "mantap"
+- "setuju"
+
+These messages may indicate conversational agreement but do not authorize execution.
+
+## Proposal Binding
+
+Approval applies only to the exact proposal presented to the user.
+
+The proposal includes:
+
+- Symbol
+- Side
+- Order type
+- Entry price or entry condition
+- Position size
+- Leverage
+- Stop loss
+- Take profit
+
+If any of these values change, the previous approval becomes invalid.
+
+A new proposal and new explicit approval are required.
+
+## Market Changes
+
+If market conditions materially change after approval but before execution, RiskGuard should invalidate the stale proposal and perform a new analysis.
+
+A new proposal requires new explicit approval.
+
+## Simulation Mode
+
+When simulation mode is enabled:
+
+- Never submit real orders.
+- Never modify real orders.
+- Never cancel real orders.
+- Clearly label simulated execution.
+- Do not imply that a simulated order was actually submitted or filled.
+
+## Execution Principle
+
+Execution must use only the exact parameters contained in the approved proposal.
+
+RiskGuard must not silently modify an approved trade.


### PR DESCRIPTION
## Summary

Add RiskGuard, a risk-control skill for AI trading agents.

RiskGuard introduces a mandatory pre-trade workflow that separates:

- Market analysis
- Risk assessment
- Trade recommendation
- Trade proposal
- Explicit user approval
- Execution

## Key Features

- Automatically activates on trading intent.
- Requires market and risk analysis before proposing a trade.
- Requires explicit approval before execution.
- Binds approval to the exact trade proposal.
- Invalidates approval when material trade parameters change.
- Handles stale proposals when market conditions materially change.
- Supports simulation mode with no real order execution.

## Files

- `skills/binance/riskguard/SKILL.md`
- `skills/binance/riskguard/references/approval-policy.md`

## Safety

RiskGuard is designed to prevent accidental trade execution caused by ambiguous conversational responses such as "ok", "gas", or "lanjut".

Execution is only permitted after explicit approval of the specific proposal.