### PR TITLE
feat: add deterministic perpetual trading risk skills

### DIFF
--- a/skills/binance-web3/perp-risk/SKILL.md
+++ b/skills/binance-web3/perp-risk/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: perp-risk
+description: |
+  Deterministic position sizing and risk calculator for a leveraged perpetual position,
+  before the order is placed. From account equity, a chosen risk budget (as % of equity),
+  an intended entry price, a stop-loss price, leverage and side, it returns position size,
+  risk budget in USDT, position notional, initial margin, stop distance and a GENERIC
+  estimated liquidation price. Call it before opening or increasing a leveraged perpetual
+  position when the agent needs deterministic, machine-readable sizing derived from account
+  equity and risk tolerance. It is a read-only calculator: it does not place orders, it does
+  not model any specific exchange's maintenance-margin tiers, fees, funding or risk parameters,
+  and it is not investment advice.
+metadata:
+  author: SangJieGe
+  version: 1.0.0
+---
+
+# Perp Risk
+
+Perpetual position sizing and risk calculator. Given equity, risk %, entry, stop, leverage
+and side, it computes the position size that keeps the worst-case stop-loss loss inside the
+risk budget, plus the resulting notional, initial margin, stop distance, and a **generic**
+estimated liquidation price for sanity-checking.
+
+## When to Use
+
+Use this skill **before opening or modifying a leveraged perpetual position** when the agent
+needs deterministic position sizing — i.e. it must turn a risk-per-trade decision into a
+concrete currency quantity and notional before quoting any order size.
+
+Trigger intents include:
+
+| Agent intent | Why this skill |
+|---|---|
+| "How much of X can I buy at entry E with a stop at S risking 1% of equity?" | Deterministic quantity from equity + risk budget + entry + stop |
+| "What notional and margin does this position need at Nx leverage?" | Position notional + initial margin |
+| "How far is my stop, and where is my liquidation roughly?" | Stop distance + generic liquidation estimate |
+| "If the market moves adversely by Y%, what do I lose / need extra?" | `target_adverse_move_pct` extra funding check |
+
+Do **not** call it when there is no stop-loss price yet — sizing a position without a defined
+exit stop is out of scope. Do not call it to place, modify or cancel any order; it only estimates.
+
+## What It Does
+
+Read-only, deterministic calculator. It accepts caller-supplied account and trade parameters
+and returns validated sizing numbers. It has **no market-data, symbol, or venue dependency** —
+prices and equity are supplied by the caller, not fetched. Outputs are stable and machine-readable
+(JSON), suitable for an agent to act on before execution.
+
+It does **not** operate any order path and does **not** model exchange-specific liquidation
+(maintenance-margin tiers, fee rates, funding, or risk-tier parameters are not included).
+
+## Input
+
+JSON request body. Required fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `equity_usdt` | number > 0 | Account usable equity in USDT |
+| `risk_pct` | number in (0, 100] | Portion of equity budgeted as the intended stop-loss risk |
+| `entry_price` | number > 0 | Intended entry price |
+| `stop_price` | number > 0 | Stop-loss; must differ from entry and sit on the correct side (below entry for long, above for short) |
+| `leverage` | number > 0 | Intended leverage multiplier |
+| `side` | string | `"long"` or `"short"` |
+
+Optional field:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `target_adverse_move_pct` | number in (0, 100) | If supplied, also reports the USDT loss at that adverse move and any extra margin needed if it exceeds equity |
+
+## Output
+
+JSON response. Deterministic fields:
+
+| Field | Meaning |
+|---|---|
+| `risk_budget_usdt` | The USDT amount at risk per this trade from the stop |
+| `quantity` | Position size in base units |
+| `position_notional_usdt` | Notional value of the position |
+| `initial_margin_usdt` | Required initial margin at chosen leverage |
+| `stop_distance_price` | Absolute price distance entry → stop |
+| `stop_distance_pct` | Stop distance as % of entry |
+
+Estimate field (always accompanied by the generic warning):
+
+| Field | Meaning |
+|---|---|
+| `estimated_liquidation_price` | **Generic** estimate only (`100 / leverage` distance model) |
+| `liquidation_estimate_warning` | Present whenever the generic liquidation estimate is returned |
+
+Conditional field (present only when `target_adverse_move_pct` supplied, else `null`):
+
+| Field | Meaning |
+|---|---|
+| `target_adverse_move_loss_usdt` | Loss in USDT at the target adverse move |
+| `extra_margin_for_target_move_usdt` | Extra margin needed if that loss exceeds equity |
+
+## API
+
+HTTP endpoint (the supplied account/trade parameters are passed straight through):
+
+```
+POST https://sangjiege.online/perp-risk/v1/perp/risk
+```
+
+Authentication: none required — the service does **not** depend on Binance API credentials.
+
+Input validation errors return `HTTP 400` with a descriptive message (invalid sign, zero stop
+distance, wrong stop side for `side`, out-of-range percentages). There is **no**
+`ALLOW` / `WARN` / `BLOCK` decision output from this endpoint — it is a pure calculator; the
+caller decides whether the returned sizing is acceptable.
+
+## Example
+
+A LONG perp risk-budgeted sizing:
+
+```json
+{
+  "equity_usdt": 10000,
+  "risk_pct": 1,
+  "entry_price": 50000,
+  "stop_price": 48000,
+  "leverage": 10,
+  "side": "long"
+}
+```
+
+Expected shape: `risk_budget_usdt = 100`, stop distance = 2000 pts, `quantity ≈ 0.05`,
+`position_notional_usdt ≈ 2500`, `initial_margin_usdt ≈ 250`, and a generic liquidation price
+≈ 45000 (entry down 10% under the `100 / leverage` model) with `liquidation_estimate_warning` present.
+
+## Use Cases
+
+1. **Pre-order sizing**: Agent computes a concrete quantity and stop before sending any perp order.
+2. **Risk-budget planning**: Agent confirms that the chosen stop keeps the worst-case loss at (or
+   around) `risk_pct` of equity.
+3. **Margin check**: Agent verifies the initial margin a candidate position would consume under a chosen leverage.
+4. **Sanity-check liquidation**: Agent reviews the generic liquidation estimate before committing
+   to a stop far from the current price.
+5. **Adverse-move assessment**: Agent checks how much a `target_adverse_move_pct` would cost and
+   whether the extra margin is fundable from equity.
+
+## Notes / Limitations
+
+- `estimated_liquidation_price` is a **generic modelling approximation** (buffer ≈ `100 / leverage`
+  %), **not** an exchange-specific liquidation engine. Exchange maintenance-margin rate, fee rates,
+  funding, and tiered risk rules are **not** modelled.
+- No funding, fees, or slippage are considered in sizing.
+- No symbol or market-data dependency: prices are supplied by the caller, not fetched.
+- Framing is generic USDT-nominated equity + generic margin; not wired to any specific venue.
+- Do not report the generic liquidation number as an exchange-accurate liquidation level.
+- This skill only describes how to use the existing read-only capability; it adds no new Binance
+  API or order-management functionality, does not place orders, does not move funds, and is not
+  investment advice.

--- a/skills/binance-web3/pre-trade-risk/SKILL.md
+++ b/skills/binance-web3/pre-trade-risk/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: pre-trade-risk
+description: |
+  Deterministic pre-execution risk decision gate for leveraged perpetual/swap trades. Given the
+  proposed trade parameters (symbol, side, equity, entry, stop, leverage, proposed position
+  notional), it maps them through a set of generic risk checks and returns an ALLOW / WARN /
+  BLOCK decision with a risk score, per-check results, computed metrics and severity-ordered
+  warning codes. Call it immediately before executing or modifying a leveraged trade, to decide
+  whether the proposed trade satisfies the risk constraints under a generic policy. It is a
+  decision gate only — it does NOT execute or modify orders, does not manage positions, and does
+  not claim to model a specific exchange's official rules.
+metadata:
+  author: SangJieGe
+  version: 1.0.0
+---
+
+# Pre-Trade Risk Guard
+
+Pre-execution risk gate for leveraged trades. It takes **proposed** trade parameters and returns
+a structured **ALLOW / WARN / BLOCK** decision so the agent can stop before sending an order that
+would breach its generic risk constraints.
+
+## When to Use
+
+Use this skill **immediately before executing or modifying a leveraged trade** when the agent must
+decide whether the proposed trade passes a deterministic pre-trade risk gate.
+
+Trigger intents include:
+
+| Agent intent | Why this skill |
+|---|---|
+| "Is this trade OK to send?" (leverage, notional, stop, risk) | Decision gate before execution |
+| Iterating on a candidate trade and re-checking each variant | Concrete ALLOW / WARN / BLOCK verdict |
+| Where is this trade risky? | Aggregate `risk_score` + per-check breakdowns |
+| Sharpen the generic model with venue data | `maintenance_margin_rate` / `fee_rate` / `funding_rate` |
+
+Do **not** present `ALLOW` as a guarantee, an exchange validation, or investment advice. Do not use
+this skill to place, modify or cancel orders — it only gates the decision. Order execution is out of scope.
+
+## What It Does
+
+Deterministic **decision gate** (`ALLOW` / `WARN` / `BLOCK`), not a trade executor. Given
+caller-supplied trade parameters, it computes metrics and runs generic checks, then folds them into
+one verdict plus a structured breakdown. Where exchange-sharpening parameters
+(`maintenance_margin_rate`, `fee_rate`, `funding_rate`) are all supplied, it narrows the liquidation
+model to a venue-sharpened one; otherwise it stays explicitly generic and never fabricates a sharper
+result.
+
+The threshold policy is a **generic** policy — it does not claim to mirror any particular
+exchange's leverage / margin tiers.
+
+## Input
+
+JSON request body. Required fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `symbol` | non-empty string | The traded symbol |
+| `side` | string | `"long"` or `"short"` |
+| `equity_usdt` | number > 0 | Account usable equity in USDT |
+| `entry_price` | number > 0 | Proposed entry price |
+| `stop_price` | number > 0 | Stop-loss; must differ from entry and sit on the correct side |
+| `leverage` | number > 0 | Proposed leverage |
+| `position_notional_usdt` | number > 0 | Proposed position notional |
+
+Optional fields (venue sharpening + risk-budget check):
+
+| Field | Type | Meaning |
+|---|---|---|
+| `maintenance_margin_rate` | number >= 0 | Exchange maintenance-margin rate (enables sharpened liquidation) |
+| `fee_rate` | number >= 0 | Exchange taker/maker fee rate |
+| `funding_rate` | number >= 0 | Expected funding rate |
+| `target_price` | number > 0 | Optional take-profit / projection |
+| `max_risk_pct` | number in (0, 100] | Risk budget as % of equity (enables the risk-budget check) |
+
+## Output
+
+JSON verdict. Structure:
+
+| Field | Meaning |
+|---|---|
+| `decision` | `ALLOW` \| `WARN` \| `BLOCK` |
+| `risk_score` | 0..100 (capped aggregate) |
+| `decision_note` | Short human-readable rationale |
+| `checks` | Per-check map: `input_sanity`, `leverage`, `exposure`, `stop_loss`, `risk_budget`, `liquidation_buffer` → `PASS` \| `WARN` \| `BLOCK` |
+| `metrics` | `equity_usdt`, `position_notional_usdt`, `exposure_ratio`, `initial_margin_usdt`, `stop_distance_pct`, `estimated_loss_at_stop_usdt`, `risk_budget_usdt` (null when no `max_risk_pct`), `risk_budget_exceeded_usdt`, `generic_estimated_liquidation_price`, `generic_liquidation_distance_pct` |
+| `warnings` | Severity-ordered list of `{ code, severity, message }` |
+| `model` | `{ type: "generic", exchange_specific: bool, disclaimer }`; `exchange_specific` is `true` only when `maintenance_margin_rate`, `fee_rate` AND `funding_rate` are all supplied |
+
+Warning / block codes the checks can surface include: `HIGH_LEVERAGE`, `HIGH_EXPOSURE`,
+`WIDE_STOP`, `TIGHT_STOP`, `RISK_BUDGET_EXCEEDED`, `LOW_LIQUIDATION_BUFFER`, `INVALID_STOP_DIRECTION`.
+
+## Decision / Rules
+
+Rule of thumb — one blocking risk drives `BLOCK`, else any warning drives `WARN`, else `ALLOW`:
+
+- **Any check at BLOCK ⇒ `decision = BLOCK`** (e.g. leverage > 30×, exposure > 5× equity,
+  estimated loss at stop > risk budget, or the stop sits behind the generic liquidation estimate).
+- **Otherwise any WARN ⇒ `decision = WARN`** (e.g. leverage > 15×, exposure > 2× equity,
+  stop > 20% or < 0.2% of entry, or stop within ~80% of the generic liquidation distance).
+- **Otherwise ⇒ `decision = ALLOW`**.
+- `BLOCK` / `WARN` / `ALLOW` reflect a **generic policy**. The venue-sharpened model applies only
+  when `maintenance_margin_rate` + `fee_rate` + `funding_rate` are all present; the guard never
+  fabricates a sharper result when they are absent.
+- Input validation errors return `HTTP 400` (never silently coerced).
+
+## API
+
+HTTP endpoint (the supplied trade parameters are passed straight through):
+
+```
+POST https://sangjiege.online/perp-risk/v1/pre-trade-guard
+```
+
+Authentication: none required — the service does **not** depend on Binance API credentials.
+
+## Example
+
+Check a high-leverage LONG trade on a $10k account before sending it:
+
+```json
+{
+  "symbol": "BTCUSDT",
+  "side": "long",
+  "equity_usdt": 10000,
+  "entry_price": 50000,
+  "stop_price": 48500,
+  "leverage": 25,
+  "position_notional_usdt": 100000,
+  "max_risk_pct": 1
+}
+```
+
+This example would surface `HIGH_LEVERAGE` / `HIGH_EXPOSURE` findings, driving a **BLOCK** verdict
+with a high `risk_score` and severity-ordered warnings — the agent should stop before sending this order.
+
+## Use Cases
+
+1. **Pre-execution gate**: Agent runs the trade through the guard and refuses to send if `BLOCK`.
+2. **Trade iteration**: Agent tweaks leverage / notional / stop and re-checks until `ALLOW` (or a
+   consciously accepted `WARN`).
+3. **Uniform risk policy**: Every leveraged order — human or autonomous — passes the same
+   deterministic gate before execution.
+4. **Stop-validity check**: Agent confirms the stop sits on the right side and in front of the
+   generic liquidation estimate.
+5. **Venue-aware re-check**: When accurate MMR / fee / funding are available, the guard sharpens
+   the liquidation model and re-verifies the stop and buffer.
+
+## Notes / Limitations
+
+- The liquidation estimate is a **generic** `100 / leverage` distance model, **not** a venue
+  liquidation price. "Stop in front of liquidation" is only meaningful under that approximation.
+- Risk thresholds are a **generic** policy, not the leverage/risk tiers of a specific exchange.
+- No order execution, no live positions, no portfolio reconciliation, no market fetching — all
+  values are caller-supplied.
+- This guard does **not** execute or modify trades and never touches funds. `ALLOW` still requires
+  the agent to complete execution through its own responsible order path.
+- A `WARN` / `BLOCK` verdict should be surfaced truthfully to the user before any order is sent.
+- Report `model.exchange_specific` and the generic-policy disclaimer alongside any surfaced verdict,
+  so it is not mistaken for a venue rule.
+- This skill only describes how to use the existing guard service; it adds no new Binance API or
+  order-management capability.


### PR DESCRIPTION
两个只读的确定性逐仓（perpetual）交易风险管理技能，发布到 `skills/binance-web3/`。

## 变更内容

| 技能 | 作用 | 端点 |
|------|------|------|
| `perp-risk` | 开仓/加仓前，由账户权益+风险预算+入场/止损/杠杆计算确定性仓位（quantity、notional、initial margin、stop distance + **generic** 预估强平价）。纯只读计算器，不执行任何订单。 | `POST https://sangjiege.online/perp-risk/v1/perp/risk` |
| `pre-trade-risk` | 下单前对拟交易参数跑确定性风险闸门，返回 **ALLOW / WARN / BLOCK** 裁决 + `risk_score` + 逐项检查 + 告警码。仅决策，不执行/不改单。 | `POST https://sangjiege.online/perp-risk/v1/pre-trade-guard` |

## 合规要点

- **纯只读**：两者均无订单执行、无持仓管理、不触碰资金、不抓取市场行情——所有价格/权益/参数均由调用方传入。
- **不上架推荐**：不含任何需推广的币种/资产，内容中性、事实性、教学性。
- **无凭据**：端点无需鉴权，不依赖 Binance API credentials；SKILL 内无任何密钥/钱包地址。
- **明确免责**：强平价与阈值均为通用模型（`100/leverage` 近似）与通用风险策略，明确声明不等同于任何交易所官方清算/保证金规则，非投资建议。

## 文件

- `skills/binance-web3/perp-risk/SKILL.md`
- `skills/binance-web3/pre-trade-risk/SKILL.md`

（未包含 token-security、requirements、服务端源码、生产配置或任何 OKX 相关文件。）
