### PR TITLE
Add rsoft-bank-credit — AI-native USDC lending skill for autonomous agents

### DIFF
--- a/skills/rsoft-bank-credit/README.md
+++ b/skills/rsoft-bank-credit/README.md
@@ -1,0 +1,49 @@
+# rsoft-bank-credit
+
+**AI-native USDC lending for autonomous agents — on Base mainnet.**
+
+This skill teaches an agent to use [RSoft Agentic Bank](https://rsoft-agentic-bank.com/):
+check its creditworthiness, request a USDC loan (EIP-712 signed with the agent's
+own wallet via Coinbase CDP), receive funds on-chain, repay autonomously, and
+build a portable **ERC-8004 on-chain credit reputation** with every repaid loan.
+
+Works with any agent framework that can run shell commands (Claude, LangChain,
+CrewAI, OpenClaw, …). MCP-capable agents can skip the scripts entirely and use
+the bank's MCP server (URL in `SKILL.md`).
+
+## ⚠️ Real money
+
+The bank operates on **Base MAINNET** with real USDC. Loans start at 5 USDC and
+grow along a credit ladder with each successful repayment. Defaults are recorded
+on-chain against the agent's reputation. Nothing in this skill promotes any
+asset; it documents a lending service, neutrally.
+
+## Requirements
+
+- `curl`, `node` (>= 18)
+- `npm install @coinbase/cdp-sdk` (one-time, for signing — keys never leave
+  Coinbase's enclave)
+- A Coinbase CDP wallet config file (see `SKILL.md`, "Wallet" section)
+- A pilot API key for loan origination (free reads/repay need none)
+
+## Scripts
+
+All helper scripts live in `scripts/` — minimal, readable Node.js, no privileges:
+
+| Script | What it does |
+|---|---|
+| `address.js` | prints the agent wallet after verifying CDP credentials control it |
+| `sign-loan.js <amount>` | signs loan terms (EIP-712) with the agent's wallet; prints the JSON request body |
+| `pay.js <to> <amount>` | sends the exact USDC repayment (CDP signs and broadcasts) |
+| `repay.js` | convenience wrapper for the repay flow |
+| `request-loan.js` | convenience wrapper for the loan request flow |
+| `wallet-config.js` | shared config loader (reads `WALLET_CONFIG_PATH`) |
+
+Run them from the skill directory, e.g. `node scripts/address.js`.
+
+## Verification
+
+- Website & docs: https://rsoft-agentic-bank.com/
+- Publisher: RSoft Latam
+- Network: Base mainnet · all transactions verifiable on BaseScan
+- Payments protocol: x402-compatible service (USDC on Base)

--- a/skills/rsoft-bank-credit/SKILL.md
+++ b/skills/rsoft-bank-credit/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: rsoft-bank-credit
+description: >
+  RSoft Agentic Bank - AI-native USDC lending on Base mainnet for autonomous agents.
+  Check creditworthiness, request loans (EIP-712 signed via Coinbase CDP), repay
+  autonomously, and build portable ERC-8004 on-chain credit reputation. Use when an
+  agent needs working capital, wants to check its credit score or interest rates,
+  or must repay an active loan. Real money; educational/neutral; no asset promotion.
+metadata:
+  version: 2.2.0
+  author: RSoft Latam
+  license: MIT
+---
+
+# RSoft Agentic Bank
+
+Official skill for **RSoft Agentic Bank** — an AI-native lending service for autonomous agents on **Base mainnet** (Coinbase L2).
+
+Agents check creditworthiness, request USDC loans, receive funds on-chain, and repay autonomously. Every repaid loan earns a bank-signed, portable **ERC-8004 reputation mark** — verifiable on-chain credit history.
+
+> ⚠️ **REAL MONEY.** This bank operates on Base MAINNET with real USDC. Defaults are recorded on-chain against your agent's reputation. Borrow only what your agent can repay.
+
+## Wallet: Coinbase CDP
+
+This skill signs and pays with a **Coinbase CDP (Developer Platform) wallet**. The
+private key never leaves Coinbase's enclave — CDP signs server-side when the skill
+presents your credentials. You point the skill at a config file, and it acts on the
+wallet that file describes; switch wallets by pointing at a different file.
+
+**One-time setup — create a config file** (keep it OUTSIDE synced folders, with
+tight permissions):
+
+```bash
+mkdir -p ~/.rsoft && cat > ~/.rsoft/wallet.env <<'EOF'
+CDP_API_KEY_ID=your-cdp-api-key-id
+CDP_API_KEY_SECRET=your-cdp-api-key-secret
+CDP_WALLET_SECRET=your-cdp-wallet-secret
+AGENT_WALLET=0xYourWalletAddress
+EOF
+chmod 600 ~/.rsoft/wallet.env
+export WALLET_CONFIG_PATH=~/.rsoft/wallet.env
+```
+
+> 🔒 **Security:** these CDP credentials control **every wallet in that CDP
+> project**. Use credentials from a CDP project dedicated to this agent — never
+> one that also holds funds you don't want the agent to touch. The config file
+> is the only place secrets live; the skill never embeds them.
+
+Install the SDK once (in the skill directory, or your workspace):
+
+```bash
+npm install @coinbase/cdp-sdk
+```
+
+## Base URLs
+
+```
+Reads & repay (free, no key):  https://7mavs5vu7ggbhtxvbavdgs26qa0cbawg.lambda-url.us-east-1.on.aws
+Loan origination (API key):    https://rsoft-agentic-bank.com/api/v1
+```
+
+## Setup: Know Your Wallet Address
+
+```bash
+node scripts/address.js
+```
+Prints your `AGENT_WALLET` after verifying the CDP credentials actually control
+it. Use this address as `{agent_id}` in all bank commands.
+
+## Available Commands
+
+### 1. Check Interest Rates (free)
+
+```bash
+curl -s https://7mavs5vu7ggbhtxvbavdgs26qa0cbawg.lambda-url.us-east-1.on.aws/api/interest-rates
+```
+
+### 2. Check Credit Score (free)
+
+Replace `{agent_id}` with your wallet address:
+```bash
+curl -s https://7mavs5vu7ggbhtxvbavdgs26qa0cbawg.lambda-url.us-east-1.on.aws/api/creditworthiness/{agent_id}
+```
+
+### 3. Request a Loan (API key + CDP signature)
+
+Two requirements — both security features, not red tape:
+
+1. **A pilot API key.** Message [@RSoft-Agentic-Bank on Moltbook](https://www.moltbook.com/u/RSoft-Agentic-Bank) to get one, then `export BANK_API_KEY=…`.
+2. **Your wallet's EIP-712 signature.** Produced by CDP; the bank only originates loans signed by the borrowing wallet.
+
+**Step 3a — sign the loan terms** (CDP signs; nothing to handle by hand):
+```bash
+node scripts/sign-loan.js 5      # 5 USDC (min 5, max per your credit ladder)
+```
+This prints a JSON body: `{ agent_wallet, loan_amount, nonce, deadline, signature }`.
+
+**Step 3b — submit the signed request** (pipe the JSON straight through):
+```bash
+node scripts/sign-loan.js 5 | curl -s -X POST \
+  -H "Content-Type: application/json" -H "X-API-Key: $BANK_API_KEY" \
+  -d @- https://rsoft-agentic-bank.com/api/v1/loan/request
+```
+Save the `request_id`. The bank's 5-agent pipeline evaluates risk and, if
+approved, sends real USDC to your wallet within seconds.
+
+If your wallet has a human **sponsor** with draft mode on and you ask for more
+than your ceiling, the bank answers **202** with `status: draft_pending_sponsor`
+— nothing is rejected, the loan waits (24h) for the sponsor's approval on the
+web console or WhatsApp (RSoft MIA). Poll step 3c. A 403 `agent_paused` means
+the sponsor paused you; `GET /api/v1/agents/{wallet}/controls` (free) shows
+your effective ceiling, caps and pending draft.
+
+**Step 3c — track it** (free, no key):
+```bash
+curl -s https://rsoft-agentic-bank.com/api/v1/loan/status/{request_id}
+```
+
+### 4. Verify the Loan Arrived
+
+Search your address on [BaseScan](https://basescan.org/), or check the loan
+status endpoint above until it reads `disbursed`.
+
+### 5. Repay a Loan (3 steps — do all 3 in order)
+
+**Step 1: Check how much you owe**
+```bash
+curl -s https://7mavs5vu7ggbhtxvbavdgs26qa0cbawg.lambda-url.us-east-1.on.aws/api/repay-info/{agent_id}
+```
+Save `request_id`, `repayment_amount`, and `pay_to`.
+
+**Step 2: Send the EXACT USDC amount** (CDP signs + broadcasts):
+```bash
+node scripts/pay.js <pay_to> <repayment_amount>
+```
+Pay **exactly** `repayment_amount` — not more, not less. Save the `tx_hash` it prints.
+
+**Step 3: Confirm repayment with the bank**
+
+WARNING: the URL is `/api/repay` — do NOT change it.
+```bash
+curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"request_id": "<request_id>", "tx_hash": "<tx_hash>"}' \
+  https://7mavs5vu7ggbhtxvbavdgs26qa0cbawg.lambda-url.us-east-1.on.aws/api/repay
+```
+Safety net: if your agent dies after Step 2, the bank auto-detects exact
+treasury payments within ~10 minutes. An agent that paid is never defaulted.
+
+## Full Workflow Example
+
+```
+1. Know your address          → node scripts/address.js
+2. Check interest rates        → curl /api/interest-rates
+3. Check your credit score     → curl /api/creditworthiness/{wallet}
+4. Sign + request the loan     → node scripts/sign-loan.js 5 | curl POST /api/v1/loan/request
+5. Verify USDC received        → curl /api/loan/status/{request_id}  (→ disbursed)
+6. Check repayment info        → curl /api/repay-info/{wallet}
+7. Send EXACT USDC to bank     → node scripts/pay.js {pay_to} {repayment_amount}
+8. Confirm repayment           → curl POST /api/repay
+```
+
+## Important Notes
+
+- **Network:** Base MAINNET — real USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`), real consequences.
+- **Loan size:** 5 USDC minimum. Your ceiling starts at the $5 floor and climbs the credit ladder with each repaid loan ($5 → $10 → $25 → …).
+- **One active loan at a time.** Repay before requesting a new one. An unpaid default blocks new loans until you cure it (repay in full via the same repay flow).
+- **Gas:** the wallet needs a small amount of ETH on Base for transaction fees.
+- All transactions are verifiable on [BaseScan](https://basescan.org/).
+
+## MCP Server (alternative for MCP-capable agents)
+
+If your agent speaks MCP, the same bank is one config line away, no API key needed:
+```
+https://7mavs5vu7ggbhtxvbavdgs26qa0cbawg.lambda-url.us-east-1.on.aws/mcp
+```
+Tools: `get_creditworthiness`, `request_loan` (carries your EIP-712 signature;
+may return `draft_pending_sponsor`), `get_loan_status`, `get_agent_controls`
+(sponsor kill switch / caps / ceiling), `get_repayment_info`, `confirm_repayment`. Full docs: [rsoft-agentic-bank.com/docs](https://rsoft-agentic-bank.com/docs).
+
+## Verification
+
+- **Official Website:** [rsoft-agentic-bank.com](https://rsoft-agentic-bank.com/)
+- **Publisher:** RSoft Latam
+- **Protocol:** REST API via curl + Coinbase CDP for signing/transfers; MCP server for tool-native agents
+- **Network:** Base mainnet (Coinbase L2)
+
+---
+*Developed by RSoft Latam — Empowering the Agentic Economy.*

--- a/skills/rsoft-bank-credit/scripts/address.js
+++ b/skills/rsoft-bank-credit/scripts/address.js
@@ -1,0 +1,20 @@
+"use strict";
+// Print the agent wallet address from the config. Verifies the CDP credentials
+// actually control it (fails loudly if not) so a misconfigured file is caught
+// before any money moves.
+const { loadConfig, cdpClient } = require("./wallet-config");
+
+(async () => {
+  const cfg = loadConfig();
+  const cdp = await cdpClient(cfg);
+  const account = await cdp.evm.getAccount({ address: cfg.AGENT_WALLET });
+  if (account.address.toLowerCase() !== cfg.AGENT_WALLET.toLowerCase()) {
+    throw new Error(
+      `Credentials do not control ${cfg.AGENT_WALLET} (resolved ${account.address})`
+    );
+  }
+  console.log(account.address);
+})().catch((e) => {
+  console.error("ERROR:", e.message);
+  process.exit(1);
+});

--- a/skills/rsoft-bank-credit/scripts/package.json
+++ b/skills/rsoft-bank-credit/scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "rsoft-agentic-bank-skill",
+  "version": "2.2.0",
+  "private": true,
+  "dependencies": {
+    "@coinbase/cdp-sdk": "^1.47.0"
+  }
+}

--- a/skills/rsoft-bank-credit/scripts/pay.js
+++ b/skills/rsoft-bank-credit/scripts/pay.js
@@ -1,0 +1,40 @@
+"use strict";
+// Send an EXACT USDC repayment from the CDP wallet to the bank treasury.
+// CDP signs and broadcasts server-side; the key never leaves the enclave.
+//
+// Usage:  node pay.js <pay_to_address> <amount_usdc>
+// Output: the transaction hash (use it in POST /loan/repay)
+const { loadConfig, cdpClient } = require("./wallet-config");
+
+const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"; // Circle USDC, Base mainnet
+
+// Minimal ERC-20 transfer calldata: transfer(address,uint256) = 0xa9059cbb
+function transferCalldata(to, amountUnits) {
+  const addr = to.toLowerCase().replace(/^0x/, "").padStart(64, "0");
+  const amt = BigInt(amountUnits).toString(16).padStart(64, "0");
+  return "0xa9059cbb" + addr + amt;
+}
+
+(async () => {
+  const payTo = process.argv[2];
+  const amount = parseFloat(process.argv[3]);
+  if (!/^0x[0-9a-fA-F]{40}$/.test(payTo || "")) throw new Error("Usage: node pay.js <pay_to 0x…> <amount_usdc>");
+  if (!(amount > 0)) throw new Error("amount_usdc must be > 0");
+
+  const cfg = loadConfig();
+  const cdp = await cdpClient(cfg);
+
+  const amountUnits = Math.round(amount * 1e6); // USDC has 6 decimals
+  const data = transferCalldata(payTo, amountUnits);
+
+  const { transactionHash } = await cdp.evm.sendTransaction({
+    address: cfg.AGENT_WALLET,
+    network: "base",
+    transaction: { to: USDC, data, value: 0n },
+  });
+
+  console.log(transactionHash);
+})().catch((e) => {
+  console.error("ERROR:", e.message);
+  process.exit(1);
+});

--- a/skills/rsoft-bank-credit/scripts/repay.js
+++ b/skills/rsoft-bank-credit/scripts/repay.js
@@ -1,0 +1,51 @@
+"use strict";
+// One-shot repayment for RSoft Agentic Bank: read the amount owed, send the
+// EXACT USDC to the treasury via CDP, and confirm with the bank. Self-contained
+// — reads creds from the config file. The private key never leaves CDP.
+//
+// Usage:  node repay.js
+// Output: each step + the bank's final repayment confirmation.
+const { loadConfig, cdpClient } = require("./wallet-config");
+
+const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"; // Circle USDC, Base mainnet
+const READS = "https://7mavs5vu7ggbhtxvbavdgs26qa0cbawg.lambda-url.us-east-1.on.aws";
+
+function transferCalldata(to, amountUnits) {
+  const addr = to.toLowerCase().replace(/^0x/, "").padStart(64, "0");
+  const amt = BigInt(amountUnits).toString(16).padStart(64, "0");
+  return "0xa9059cbb" + addr + amt;
+}
+
+(async () => {
+  const cfg = loadConfig();
+
+  // 1) What do we owe?
+  const infoRes = await fetch(`${READS}/api/repay-info/${cfg.AGENT_WALLET}`);
+  const info = await infoRes.json();
+  if (!info.request_id || !info.repayment_amount || !info.pay_to) {
+    throw new Error("No active loan to repay (or repay-info unavailable): " + JSON.stringify(info));
+  }
+  console.log(`Owe ${info.repayment_amount} USDC on ${info.request_id} → ${info.pay_to}`);
+
+  // 2) Pay the EXACT amount via CDP
+  const cdp = await cdpClient(cfg);
+  const amountUnits = Math.round(info.repayment_amount * 1e6);
+  const { transactionHash } = await cdp.evm.sendTransaction({
+    address: cfg.AGENT_WALLET,
+    network: "base",
+    transaction: { to: USDC, data: transferCalldata(info.pay_to, amountUnits), value: 0n },
+  });
+  console.log(`Paid — tx ${transactionHash}`);
+
+  // 3) Confirm with the bank
+  const confRes = await fetch(`${READS}/api/repay`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ request_id: info.request_id, tx_hash: transactionHash }),
+  });
+  console.log(`Confirm HTTP ${confRes.status}`);
+  console.log(await confRes.text());
+})().catch((e) => {
+  console.error("ERROR:", e.message);
+  process.exit(1);
+});

--- a/skills/rsoft-bank-credit/scripts/request-loan.js
+++ b/skills/rsoft-bank-credit/scripts/request-loan.js
@@ -1,0 +1,67 @@
+"use strict";
+// One-shot loan origination for RSoft Agentic Bank: sign the EIP-712 LoanRequest
+// with the CDP wallet and POST it to the bank. Self-contained — reads creds AND
+// the bank API key from the config file, so it doesn't depend on shell env
+// inheritance. The private key never leaves Coinbase's enclave.
+//
+// Usage:  node request-loan.js <amount_usdc>
+// Config file (WALLET_CONFIG_PATH) must also contain BANK_API_KEY.
+// Output: the bank's JSON response ({ request_id, status, ... }).
+const crypto = require("crypto");
+const { loadConfig, cdpClient } = require("./wallet-config");
+
+const CHAIN_ID = 8453;
+const VERIFYING_CONTRACT = "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432";
+const BANK = "https://rsoft-agentic-bank.com/api/v1";
+
+(async () => {
+  const amount = parseFloat(process.argv[2]);
+  if (!(amount > 0)) throw new Error("Usage: node request-loan.js <amount_usdc> (>0)");
+
+  const cfg = loadConfig();
+  if (!cfg.BANK_API_KEY) throw new Error("Config file is missing BANK_API_KEY");
+
+  const cdp = await cdpClient(cfg);
+  const account = await cdp.evm.getAccount({ address: cfg.AGENT_WALLET });
+
+  const nonce = "cdp-" + crypto.randomBytes(8).toString("hex");
+  const deadline = Math.floor(Date.now() / 1000) + 900;
+
+  const signature = await account.signTypedData({
+    domain: { name: "RSoft Agentic Bank", version: "1", chainId: CHAIN_ID, verifyingContract: VERIFYING_CONTRACT },
+    types: {
+      LoanRequest: [
+        { name: "agentWallet", type: "address" },
+        { name: "loanAmountUsdc6", type: "uint256" },
+        { name: "nonce", type: "string" },
+        { name: "deadline", type: "uint256" },
+      ],
+    },
+    primaryType: "LoanRequest",
+    message: {
+      agentWallet: account.address,
+      loanAmountUsdc6: BigInt(Math.round(amount * 1e6)),
+      nonce,
+      deadline: BigInt(deadline),
+    },
+  });
+
+  const res = await fetch(`${BANK}/loan/request`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-API-Key": cfg.BANK_API_KEY },
+    body: JSON.stringify({
+      agent_wallet: account.address,
+      loan_amount: amount,
+      nonce,
+      deadline,
+      signature,
+    }),
+  });
+  const text = await res.text();
+  console.log(`HTTP ${res.status}`);
+  console.log(text);
+  if (!res.ok) process.exit(1);
+})().catch((e) => {
+  console.error("ERROR:", e.message);
+  process.exit(1);
+});

--- a/skills/rsoft-bank-credit/scripts/sign-loan.js
+++ b/skills/rsoft-bank-credit/scripts/sign-loan.js
@@ -1,0 +1,61 @@
+"use strict";
+// Sign the EIP-712 LoanRequest for RSoft Agentic Bank with the CDP wallet.
+// The private key never leaves Coinbase's enclave — CDP signs server-side.
+//
+// Usage:  node sign-loan.js <amount_usdc>
+// Output: JSON { agent_wallet, loan_amount, nonce, deadline, signature }
+//         (feed this straight into the POST /loan/request body)
+const crypto = require("crypto");
+const { loadConfig, cdpClient } = require("./wallet-config");
+
+const CHAIN_ID = 8453; // Base mainnet
+const VERIFYING_CONTRACT = "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432"; // ERC-8004 domain
+
+(async () => {
+  const amount = parseFloat(process.argv[2]);
+  if (!(amount > 0)) throw new Error("Usage: node sign-loan.js <amount_usdc> (>0)");
+
+  const cfg = loadConfig();
+  const cdp = await cdpClient(cfg);
+  const account = await cdp.evm.getAccount({ address: cfg.AGENT_WALLET });
+
+  const nonce = "cdp-" + crypto.randomBytes(8).toString("hex");
+  const deadline = Math.floor(Date.now() / 1000) + 900; // 15 min
+
+  const signature = await account.signTypedData({
+    domain: {
+      name: "RSoft Agentic Bank",
+      version: "1",
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+    },
+    types: {
+      LoanRequest: [
+        { name: "agentWallet", type: "address" },
+        { name: "loanAmountUsdc6", type: "uint256" },
+        { name: "nonce", type: "string" },
+        { name: "deadline", type: "uint256" },
+      ],
+    },
+    primaryType: "LoanRequest",
+    message: {
+      agentWallet: account.address,
+      loanAmountUsdc6: BigInt(Math.round(amount * 1e6)),
+      nonce,
+      deadline: BigInt(deadline),
+    },
+  });
+
+  console.log(
+    JSON.stringify({
+      agent_wallet: account.address,
+      loan_amount: amount,
+      nonce,
+      deadline,
+      signature,
+    })
+  );
+})().catch((e) => {
+  console.error("ERROR:", e.message);
+  process.exit(1);
+});

--- a/skills/rsoft-bank-credit/scripts/wallet-config.js
+++ b/skills/rsoft-bank-credit/scripts/wallet-config.js
@@ -1,0 +1,58 @@
+"use strict";
+// Shared config loader for the RSoft Agentic Bank skill (CDP mode).
+//
+// Reads the CDP credentials + agent wallet from a config file whose path is
+// given by WALLET_CONFIG_PATH (or the first CLI arg). The file is plain
+// KEY=VALUE lines (a dotenv-style file). Keeping creds in a file the operator
+// controls — instead of baking them into the skill — lets an agent switch the
+// wallet it borrows from by pointing at a different config, and keeps secrets
+// out of the skill and out of shell history.
+//
+// Required keys in the config file:
+//   CDP_API_KEY_ID
+//   CDP_API_KEY_SECRET
+//   CDP_WALLET_SECRET
+//   AGENT_WALLET          (0x… address the CDP credentials control)
+const fs = require("fs");
+
+function loadConfig() {
+  const path = process.env.WALLET_CONFIG_PATH || process.argv[2];
+  if (!path) {
+    throw new Error(
+      "No wallet config. Set WALLET_CONFIG_PATH to a file with CDP_API_KEY_ID, " +
+        "CDP_API_KEY_SECRET, CDP_WALLET_SECRET and AGENT_WALLET."
+    );
+  }
+  if (!fs.existsSync(path)) throw new Error(`Wallet config not found at: ${path}`);
+
+  const cfg = {};
+  for (const raw of fs.readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    let key = line.slice(0, eq).trim().replace(/^export\s+/, "");
+    let val = line.slice(eq + 1).trim().replace(/^["']|["']$/g, "");
+    cfg[key] = val;
+  }
+
+  const required = ["CDP_API_KEY_ID", "CDP_API_KEY_SECRET", "CDP_WALLET_SECRET", "AGENT_WALLET"];
+  const missing = required.filter((k) => !cfg[k]);
+  if (missing.length) throw new Error(`Config file missing: ${missing.join(", ")}`);
+  return cfg;
+}
+
+// cdp-sdk pulls in `jose`, which is ESM-only. A plain require() of the SDK can
+// fail ("require() of ES Module ... not supported") depending on how Node
+// resolves it in the caller's context. A dynamic import() loads the ESM graph
+// correctly everywhere, so this is async.
+async function cdpClient(cfg) {
+  const { CdpClient } = await import("@coinbase/cdp-sdk");
+  return new CdpClient({
+    apiKeyId: cfg.CDP_API_KEY_ID,
+    apiKeySecret: cfg.CDP_API_KEY_SECRET,
+    walletSecret: cfg.CDP_WALLET_SECRET,
+  });
+}
+
+module.exports = { loadConfig, cdpClient };


### PR DESCRIPTION
## What this adds

`skills/rsoft-bank-credit` — a skill that teaches any agent (any framework: Claude, LangChain, CrewAI, OpenClaw, …) to use **RSoft Agentic Bank**, an AI-native lending service for autonomous agents live on **Base mainnet**:

- Check creditworthiness and interest rates (free, no key)
- Request USDC loans, EIP-712-signed by the agent's own wallet via Coinbase CDP (keys never leave the enclave)
- Repay autonomously with an exact-amount safety net (agents that paid are never defaulted)
- Every repaid loan earns a bank-signed, portable **ERC-8004 on-chain reputation mark** — verifiable credit history that travels with the agent
- Human-sponsor guardrails: draft mode, ceilings, kill switch (agents can query their own limits)
- MCP alternative documented for tool-native agents

## Structure & compliance

- `SKILL.md` with the required frontmatter (name, description, version, license)
- `README.md` documenting requirements and every script
- `scripts/` — minimal, readable, non-privileged Node.js helpers (signing/paying via `@coinbase/cdp-sdk`, documented dependency)
- Trading rules: content is neutral and educational; no asset promotion, no guarantees, no wallet addresses embedded (payment targets come from the API per-loan)
- Clearly labeled **real-money** warnings throughout

## Verification

- Live service & docs: https://rsoft-agentic-bank.com/
- Publisher: RSoft Latam · Network: Base mainnet · txs verifiable on BaseScan
- The service has processed real autonomous loan cycles (agents borrowing and repaying with no human in the loop)

Happy to adjust anything — category placement, naming, or content — to fit the hub's conventions.


