### PR TITLE
Add afterbell skill — order-size safety check for tokenized equities across market hours

### DIFF
--- a/skills/afterbell/README.md
+++ b/skills/afterbell/README.md
@@ -1,5 +1,8 @@
 # AFTERBELL — market protection for tokenized equities
 
+**AFTERBELL is an autonomous safety agent for AI agents trading Binance bStocks
+through Agent OS.**
+
 A bStock trades around the clock. The U.S. stock it takes its price from does
 not: it trades on weekday sessions and then stops updating. So a token can keep
 moving all weekend while the last independent price of the thing underneath it

--- a/skills/afterbell/README.md
+++ b/skills/afterbell/README.md
@@ -19,6 +19,29 @@ changes, or cancels an order, and it holds no exchange credential.
 [`SKILL.md`](SKILL.md) — when to use it, how to call it, what a result means,
 and what it refuses to do.
 
+## What it does between requests
+
+The monitor runs unattended. Each cycle is reduced to the bands the limits
+already respond to, and when one of them moves it records the change on its own
+and says why it matters:
+
+```text
+AFTERBELL noticed a material change on NVDABUSDT.
+
+Reference market: RTH_OPEN -> CLOSED_WEEKEND
+Safety posture: Clear -> Smaller size
+
+The market that supplies the independent price changed session.
+The size AFTERBELL is willing to stand behind changed as a result.
+
+Nobody asked for this. No order was created and no authorization was issued.
+```
+
+Nothing is signed when this happens and no order is created. An authorization
+is bound to one specific proposal, and a background observation has no proposal
+behind it. The record exists so a later request is judged against a current
+picture rather than a stale one. Read it with `get_safety_posture`.
+
 ## What it is built on
 
 Measurements come from ordinary deterministic code, not from a model. A model

--- a/skills/afterbell/README.md
+++ b/skills/afterbell/README.md
@@ -1,0 +1,64 @@
+# AFTERBELL — market protection for tokenized equities
+
+A bStock trades around the clock. The U.S. stock it takes its price from does
+not: it trades on weekday sessions and then stops updating. So a token can keep
+moving all weekend while the last independent price of the thing underneath it
+gets older and older.
+
+AFTERBELL measures that gap and treats it as a risk input. The longer the
+reference market has been shut, the less new exposure it will permit. It applies
+the same idea when the token book is thin, when the token and the reference
+price disagree, when the instrument cannot be identified exactly, or when
+current account holdings are unknown.
+
+It is a check, not a trader. It returns a size and a reason. It never places,
+changes, or cancels an order, and it holds no exchange credential.
+
+## What is in this skill
+
+[`SKILL.md`](SKILL.md) — when to use it, how to call it, what a result means,
+and what it refuses to do.
+
+## What it is built on
+
+Measurements come from ordinary deterministic code, not from a model. A model
+can explain a result; it cannot supply a price, a limit, or an outcome.
+
+Published measurements, from the project's own recorder:
+
+- 39,895 recorded order books and 36,045 reference prices
+- 868 regular-hours observations per token against a 300 minimum, plus 1,440
+  observations captured across a market holiday
+- 35 hostile request patterns across two market conditions, none of which
+  raised the permitted size above its control
+- 6 of 6 positive controls, so the test cannot pass by refusing everything
+
+The reports are generated, not written by hand:
+[calibration](https://github.com/Jennycruzy/afterbell/blob/main/docs/calibration.md),
+[evaluation](https://github.com/Jennycruzy/afterbell/blob/main/docs/evaluation.md).
+
+## How it reaches an order
+
+AFTERBELL signs a short-lived, single-use authorization for a size it permitted.
+A supported client submits exactly that, and the record written afterwards
+carries the requested, permitted, and actually-spent amounts side by side, with
+the spent amount read back from the venue response.
+
+One order has been placed this way end to end: a 5.00 USDT buy of `NVDABUSDT`,
+of which 4.86192 USDT was spent, recorded in
+[`docs/live-acceptance.md`](https://github.com/Jennycruzy/afterbell/blob/main/docs/live-acceptance.md).
+
+To be exact about what that guarantees: the venue's own tools do not check
+AFTERBELL's signature, and the account session belongs to the client rather than
+to this package. So the promise is about the handoff — that path never produces
+an order larger than AFTERBELL permitted, and the record shows what was actually
+spent. It is not a restriction on everything the client's own credential can do.
+Restricting that would mean holding it, which this skill does not.
+
+## Links
+
+- Source and tests: <https://github.com/Jennycruzy/afterbell>
+- Live dashboard: <https://afterbell.site>
+
+Tokenized securities are certificates and do not imply direct ownership of the
+share underneath. This is a technical control, not advice or a recommendation.

--- a/skills/afterbell/SKILL.md
+++ b/skills/afterbell/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: afterbell-calendar-risk
+description: >-
+  Safety check for Binance bStocks (tokenized U.S. equities). Use it before a
+  bStock order. It compares the always-open token market with the opening hours
+  and condition of the U.S. stock market underneath it, then returns the largest
+  order size it is willing to permit, with the reason. It never places, changes,
+  or cancels an order, and it holds no exchange credential.
+license: MIT
+metadata:
+  version: "1.0.0"
+  author: Jennycruzy
+---
+
+# AFTERBELL — market protection for tokenized equities
+
+## The idea
+
+bStocks can trade around the clock. The U.S. market that supplies their
+reference price is open for only part of the week. AFTERBELL measures that gap,
+checks the live token book, and limits new exposure when the independent price
+is old or the market is unusually difficult to trade.
+
+Use this skill before a bStock order. It returns the largest amount the system
+is willing to permit and a short explanation. It cannot place, amend, or cancel
+an order, and it holds no exchange credential.
+
+## When to use it
+
+- Before buying or selling one of the five supported pairs:
+  `NVDABUSDT`, `TSLABUSDT`, `MUBUSDT`, `CRCLBUSDT`, or `SNDKBUSDT`.
+- When a request names a company rather than an exact instrument. “Buy Nvidia”
+  needs an explicit resolution to the token certificate, issuer, network, and
+  underlying stock.
+- When a contract address or current account exposure needs checking.
+
+Do not use it to choose an investment or predict a price. It only constrains an
+order proposed by something else.
+
+## Adoption
+
+```python
+from afterbell import Guard, OrderRequest, Side
+
+guard = Guard.from_policy("config/policy.yaml")
+order = OrderRequest("NVDABUSDT", Side.BUY, 5000.0, query="buy Nvidia")
+decision = guard.evaluate(order)
+if decision.allowed_notional > 0:
+    mcp.place_order(order.at(decision.allowed_notional))
+```
+
+`order.at()` refuses to increase the requested amount. From a shell:
+
+```bash
+python -m afterbell.engine \
+  --symbol NVDABUSDT --notional 5000 --query "buy Nvidia"
+```
+
+## What a result means
+
+```text
+Reference market: weekend closure · reference age 16h
+Market timing: smaller size · independent price will not refresh for 73.5h
+Liquidity: blocked · regular-hours comparison is not available yet
+Price agreement: clear · token is 3 bps from the reference
+Corporate actions: caution · current venue status is clear; future notice is not guaranteed
+Instrument identity: clear · exact certificate and underlying resolved
+Contract address: clear · address matches the checked registry
+Account exposure: blocked · recent signed account report was not supplied
+
+Decision: blocked · requested 5,000 → allowed 0 USDT
+```
+
+The amount is the smallest safe ceiling from those independent observations.
+The result is recorded in the append-only decision history.
+
+## Why an account report can stop an order
+
+Before adding exposure, AFTERBELL needs a recent, signed view of what the
+account already holds across the supported symbols. If that report is missing,
+stale, unsigned, or altered, the system will not pretend the account is empty.
+It refuses new exposure instead.
+
+The report carries signed USDT notionals and a verification signature. It does
+not carry an exchange login, and AFTERBELL stores only its identity and result,
+not the raw account export.
+
+## Configure the order limit
+
+The starting amount is the `base_notional_usdt` value in
+[`config/policy.yaml`](https://github.com/Jennycruzy/afterbell/blob/main/config/policy.yaml). Choose the maximum amount one request may ask for there.
+The market checks can reduce it when the reference price is old, the book is
+thin, the token and reference disagree, the instrument is unclear, or current
+account exposure is not known.
+
+The dashboard shows the current amount and links directly to the configuration.
+
+## What it protects against
+
+- stale or missing underlying-market prices;
+- thin books and unusually expensive fills;
+- large token/reference price differences;
+- reported venue restrictions or corporate-action messages;
+- ambiguous instruments and counterfeit contract addresses;
+- unknown aggregate account exposure; and
+- prompt injection, urgency, authority claims, or fabricated measurements.
+
+All measurements and limits are computed by ordinary deterministic code. A
+language model may narrate a recorded result, but it cannot supply a number or
+change the result.
+
+## Boundaries and evidence
+
+The public dashboard at <https://afterbell.site> shows the current order limit,
+measurements, and recorded decisions. It does not place orders. The recorder,
+dashboard, and evaluator hold no exchange credential. Any future order
+submission stays outside this dashboard and uses a supported client.
+
+The data report, safety-test report, acceptance record, and signed account-input
+runbook are linked from the dashboard and repository:
+
+- [`docs/calibration.md`](https://github.com/Jennycruzy/afterbell/blob/main/docs/calibration.md)
+- [`docs/evaluation.md`](https://github.com/Jennycruzy/afterbell/blob/main/docs/evaluation.md)
+- [`docs/live-acceptance.md`](https://github.com/Jennycruzy/afterbell/blob/main/docs/live-acceptance.md)
+- [`docs/position-input.md`](https://github.com/Jennycruzy/afterbell/blob/main/docs/position-input.md)
+
+Tokenized securities are certificates and do not imply direct ownership of the
+underlying share. This skill is a technical control, not advice or a
+recommendation.
+
+Source and tests: <https://github.com/Jennycruzy/afterbell>

--- a/skills/afterbell/SKILL.md
+++ b/skills/afterbell/SKILL.md
@@ -37,6 +37,18 @@ an order, and it holds no exchange credential.
 Do not use it to choose an investment or predict a price. It only constrains an
 order proposed by something else.
 
+## What it notices on its own
+
+Between requests the monitor keeps watching. When the reference market changes
+session, the independent price ages past a threshold the limits respond to, the
+book leaves its normal range, the token drifts from the reference, the venue
+changes what it reports, or account evidence expires, it records that change and
+explains why it matters.
+
+It does not create an order or a standing permission when it does this. The
+record is there so that the next request is judged against a current picture.
+Ask `get_safety_posture` to read it.
+
 ## Adoption
 
 ```python

--- a/skills/afterbell/SKILL.md
+++ b/skills/afterbell/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: afterbell-calendar-risk
 description: >-
-  Safety check for Binance bStocks (tokenized U.S. equities). Use it before a
-  bStock order. It compares the always-open token market with the opening hours
-  and condition of the U.S. stock market underneath it, then returns the largest
-  order size it is willing to permit, with the reason. It never places, changes,
-  or cancels an order, and it holds no exchange credential.
+  Autonomous safety agent for AI agents trading Binance bStocks (tokenized U.S.
+  equities). Use before a bStock order: it compares token-market conditions with
+  the hours and condition of the underlying U.S. market and returns the largest
+  defensible amount, and it notices material safety changes on its own between
+  requests. Its limits are deterministic; it never places an order.
 license: MIT
 metadata:
   version: "1.0.0"
@@ -16,10 +16,16 @@ metadata:
 
 ## The idea
 
-bStocks can trade around the clock. The U.S. market that supplies their
-reference price is open for only part of the week. AFTERBELL measures that gap,
-checks the live token book, and limits new exposure when the independent price
-is old or the market is unusually difficult to trade.
+AFTERBELL is an autonomous safety agent that serves AI trading agents. bStocks
+can trade around the clock. The U.S. market that supplies their reference price
+is open for only part of the week. AFTERBELL measures that gap, checks the live
+token book, and limits new exposure when the independent price is old or the
+market is unusually difficult to trade.
+
+The trading agent owns the intent. AFTERBELL independently owns the safety
+limit. Binance Agent OS owns authenticated execution. The limits are computed by
+ordinary deterministic code: a language model may explain a result, it cannot
+choose the permitted amount or overturn a refusal.
 
 Use this skill before a bStock order. It returns the largest amount the system
 is willing to permit and a short explanation. It cannot place, amend, or cancel


### PR DESCRIPTION
## What this adds

`skills/afterbell/` — a safety check to run before a bStock order.

A bStock trades around the clock. The U.S. stock it takes its price from does not: it trades on weekday sessions and then stops updating. A token can therefore keep moving all weekend while the last independent price of the thing underneath it gets older and older. An ordinary order-size check does not see that.

AFTERBELL measures the gap and treats it as a risk input. The longer the reference market has been shut, the less new exposure it permits. It applies the same idea when the token book is thin, when the token and reference price disagree, when the instrument cannot be identified exactly, or when current account holdings are unknown.

It returns a size and a reason. It never places, changes, or cancels an order, and it holds no exchange credential.

## Supported pairs

`NVDABUSDT`, `TSLABUSDT`, `MUBUSDT`, `CRCLBUSDT`, `SNDKBUSDT`

## Evidence

Measurements come from deterministic code rather than a model, and the reports are generated rather than written by hand:

- 39,895 recorded order books and 36,045 reference prices
- 868 regular-hours observations per token against a 300 minimum, plus 1,440 observations captured across a market holiday
- 35 hostile request patterns across two market conditions; none raised the permitted size above its control
- 6 of 6 positive controls, so the suite cannot pass by refusing everything

One order has been placed end to end through the signed handoff: a 5.00 USDT buy of `NVDABUSDT`, of which 4.86192 USDT was spent.

## Scope

The venue's own tools do not check AFTERBELL's signature, and the account session belongs to the client rather than to the skill. So the guarantee is about the handoff — that path never produces an order larger than AFTERBELL permitted, and the record shows what was actually spent. It is not a restriction on everything the client's credential can do; that would mean holding the credential, which this skill does not.

Source and tests: https://github.com/Jennycruzy/afterbell